### PR TITLE
Move logic for checking if statement already has comments

### DIFF
--- a/src/manipulators/no_implicit_returns_manipulator.ts
+++ b/src/manipulators/no_implicit_returns_manipulator.ts
@@ -16,7 +16,7 @@
 
 import {Diagnostic, ts, Node, SyntaxKind, StatementedNode} from 'ts-morph';
 import {Manipulator} from './manipulator';
-import {ErrorCodes} from 'src/types';
+import {ErrorCodes, NO_IMPLICIT_RETURNS_COMMENT} from 'src/types';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
 
 /**
@@ -94,9 +94,7 @@ export class NoImplicitReturnsManipulator extends Manipulator {
   }
 
   private addChildReturnStatement(node: StatementedNode): void {
-    node.addStatements(
-      '// typescript-flag-upgrade automated fix: --noImplicitReturns'
-    );
+    node.addStatements(NO_IMPLICIT_RETURNS_COMMENT);
     node.addStatements('return undefined;');
   }
 }

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -65,7 +65,7 @@ export class StrictNullChecksManipulator extends Manipulator {
   }
 
   /**
-   * Manipulates AST of project to fix for the noImplicitReturns compiler flag given diagnostics.
+   * Manipulates AST of project to fix for the strictNullChecks compiler flag given diagnostics.
    * @param {Diagnostic<ts.Diagnostic>[]} diagnostics - List of diagnostics outputted by parser
    */
   fixErrors(diagnostics: Diagnostic<ts.Diagnostic>[]): void {

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -31,7 +31,11 @@ import {
   Statement,
   PropertySignature,
 } from 'ts-morph';
-import {ErrorCodes, DeclarationType} from 'src/types';
+import {
+  ErrorCodes,
+  DeclarationType,
+  STRICT_NULL_CHECKS_COMMENT,
+} from 'src/types';
 
 /**
  * Manipulator that fixes for the strictNullChecks compiler flag.
@@ -194,21 +198,12 @@ export class StrictNullChecksManipulator extends Manipulator {
     });
 
     // Insert comment before each modified statement
-    const comment =
-      '// typescript-flag-upgrade automated fix: --strictNullChecks';
-
     modifiedStatementedNodes.forEach(
       ([modifiedStatementedNode, indexToInsert]) => {
-        if (
-          !modifiedStatementedNode
-            .getStatements()
-            [indexToInsert]?.getLeadingCommentRanges()
-            .some(commentRange => {
-              return commentRange.getText().includes(comment);
-            })
-        ) {
-          modifiedStatementedNode.insertStatements(indexToInsert, comment);
-        }
+        modifiedStatementedNode.insertStatements(
+          indexToInsert,
+          STRICT_NULL_CHECKS_COMMENT
+        );
       }
     );
   }
@@ -531,7 +526,13 @@ export class StrictNullChecksManipulator extends Manipulator {
   ): void {
     const parent = statement.getParent();
 
-    if (parent && Node.isStatementedNode(parent)) {
+    if (
+      parent &&
+      Node.isStatementedNode(parent) &&
+      !statement.getLeadingCommentRanges().some(commentRange => {
+        return commentRange.getText().includes(STRICT_NULL_CHECKS_COMMENT);
+      })
+    ) {
       statementedNotes.add([parent, statement.getChildIndex()]);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,3 +65,8 @@ export type DeclarationType = Map<
   | PropertySignature,
   Set<string>
 >;
+
+export const STRICT_NULL_CHECKS_COMMENT =
+  '// typescript-flag-upgrade automated fix: --strictNullChecks';
+export const NO_IMPLICIT_RETURNS_COMMENT =
+  '// typescript-flag-upgrade automated fix: --noImplicitReturns';


### PR DESCRIPTION
Refactor some of the code responsible for adding comments in front of modified statements to be cleaner. 