### PR TITLE
Add fixes for no overload matches error for strictNullChecks

### DIFF
--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -53,6 +53,7 @@ export class StrictNullChecksManipulator extends Manipulator {
         ErrorCodes.ObjectPossiblyNullOrUndefined,
         ErrorCodes.TypeANotAssignableToTypeB,
         ErrorCodes.ArgumentNotAssignableToParameter,
+        ErrorCodes.NoOverloadMatches,
       ])
     );
     this.nodeKinds = new Set<SyntaxKind>([
@@ -119,7 +120,8 @@ export class StrictNullChecksManipulator extends Manipulator {
         }
 
         // When argument and parameter types are not assignable to each other
-        case ErrorCodes.ArgumentNotAssignableToParameter: {
+        case ErrorCodes.ArgumentNotAssignableToParameter:
+        case ErrorCodes.NoOverloadMatches: {
           this.handleNonAssignableArgumentTypes(
             errorNode,
             diagnostic,

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export enum ErrorCodes {
   ObjectPossiblyNullOrUndefined = 2533,
   TypeANotAssignableToTypeB = 2322,
   ArgumentNotAssignableToParameter = 2345,
+  NoOverloadMatches = 2769,
 }
 
 export type DeclarationType = Map<

--- a/test/test_files/golden/strict_null_checks/unassignable_argument_type.ts
+++ b/test/test_files/golden/strict_null_checks/unassignable_argument_type.ts
@@ -28,3 +28,9 @@ function addToEmptyList() {
   const emptyList: any[] = [];
   emptyList.push(5);
 }
+
+// Test: No overload matches
+function noOverloadMatches(n: number | undefined) {
+  // typescript-flag-upgrade automated fix: --strictNullChecks
+  new Date(n!);
+}

--- a/test/test_files/strict_null_checks/unassignable_argument_type.ts
+++ b/test/test_files/strict_null_checks/unassignable_argument_type.ts
@@ -28,3 +28,9 @@ function addToEmptyList() {
   const emptyList = [];
   emptyList.push(5);
 }
+
+// Test: No overload matches
+function noOverloadMatches(n: number | undefined) {
+  // Fix: new Date(n!);
+  new Date(n);
+}


### PR DESCRIPTION
Just added an additional edge case I missed when implementing the fix for strictNullChecks.