### PR TITLE
Add initial project validation before running

### DIFF
--- a/src/emitters/emitter.ts
+++ b/src/emitters/emitter.ts
@@ -18,18 +18,9 @@ import {Project} from 'ts-morph';
 
 /** Base class for emitting modified TypeScript files. */
 export abstract class Emitter {
-  project: Project;
-
-  /**
-   * Sets project to be emitted.
-   * @param {Project} project - ts-morph project to be emitted.
-   */
-  constructor(project: Project) {
-    this.project = project;
-  }
-
   /**
    * Emits project, implemented by subclasses.
+   * @param {Project} project - ts-morph project to be emitted.
    */
-  emit(): void {}
+  abstract emit(project: Project): void;
 }

--- a/src/emitters/in_place_emitter.ts
+++ b/src/emitters/in_place_emitter.ts
@@ -22,14 +22,11 @@ import {Project} from 'ts-morph';
  * @extends {Emitter}
  */
 export class InPlaceEmitter extends Emitter {
-  constructor(project: Project) {
-    super(project);
-  }
-
   /**
    * Overwrites original input source files.
+   * @param {Project} project - ts-morph project to be emitted.
    */
-  emit(): void {
-    this.project.saveSync();
+  emit(project: Project): void {
+    project.saveSync();
   }
 }

--- a/src/emitters/out_of_place_emitter.ts
+++ b/src/emitters/out_of_place_emitter.ts
@@ -27,20 +27,20 @@ export class OutOfPlaceEmitter extends Emitter {
 
   /**
    * Sets project and output path to be emitted to.
-   * @param {Project} project - ts-morph project to be emitted.
    * @param {string} outputPath - Relative path to output directory.
    */
-  constructor(project: Project, outputPath = './ts_upgrade') {
-    super(project);
+  constructor(outputPath = './ts_upgrade') {
+    super();
     this.outputPath = outputPath;
   }
 
   /**
    * Creates output directory and copies modified source files to it.
+   * @param {Project} project - ts-morph project to be emitted.
    */
-  emit(): void {
-    const srcDirs = this.project.getRootDirectories();
-    const sourceFiles = this.project.getSourceFiles();
+  emit(project: Project): void {
+    const srcDirs = project.getRootDirectories();
+    const sourceFiles = project.getSourceFiles();
 
     srcDirs.forEach(srcDir => {
       const destDir = srcDir.createDirectory(

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,13 +18,14 @@
 
 import yargs from 'yargs';
 import {Runner} from './runner';
+import {DEFAULT_ARGS} from './types';
 
 const args = yargs
   .options({
     p: {
       alias: 'project',
       demandOption: true,
-      default: 'tsconfig.json',
+      default: DEFAULT_ARGS.p,
       description:
         'Relative path to TypeScript config file (eg. "./dir/tsconfig.json")',
       normalize: true,
@@ -33,7 +34,7 @@ const args = yargs
     m: {
       alias: 'mode',
       demandOption: true,
-      default: 'all',
+      default: DEFAULT_ARGS.m,
       description:
         "Option between only leaving comments ('comment') or both comments and mutative fixes ('all')",
       type: 'string',

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -18,13 +18,9 @@ import {Diagnostic, ts, Project} from 'ts-morph';
 
 /** Class for parsing a project and returning diagnostics. */
 export class Parser {
-  private project: Project;
+  constructor() {}
 
-  constructor(project: Project) {
-    this.project = project;
-  }
-
-  parse(): Diagnostic<ts.Diagnostic>[] {
-    return this.project.getPreEmitDiagnostics();
+  parse(project: Project): Diagnostic<ts.Diagnostic>[] {
+    return project.getPreEmitDiagnostics();
   }
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -63,13 +63,8 @@ export class Runner {
     if (project) {
       this.project = project;
     } else if (args) {
-      if (this.verifyProject(args)) {
-        this.project = this.createProject(args);
-      } else {
-        throw new Error(
-          'Project not current compiling with flags set to false.'
-        );
-      }
+      this.verifyProject(args);
+      this.project = this.createProject(args);
     } else {
       throw new Error('Neither arguments nor project provided.');
     }
@@ -154,11 +149,17 @@ export class Runner {
     });
   }
 
-  private verifyProject(args: ArgumentOptions): boolean {
-    return this.parser
-      .parse(this.createProject(args, false))
-      .every(diagnostic => {
+  /**
+   * Verifies that the project user passes in through CLI compiles initially with flags set to false.
+   * @param {ArgumentOptions} args - CLI Arguments containing project properties.
+   */
+  private verifyProject(args: ArgumentOptions): void {
+    if (
+      !this.parser.parse(this.createProject(args, false)).every(diagnostic => {
         return diagnostic.getCategory() !== ts.DiagnosticCategory.Error;
-      });
+      })
+    ) {
+      throw new Error('Project not current compiling with flags set to false.');
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,11 +34,23 @@ export type ArgumentOptions = {
    */
   m: string;
   /** Override config and specify input directory */
-  i: string | undefined;
+  i?: string;
   /** Specify file for logging */
-  l: string | undefined;
+  l?: string;
   _: string[];
   $0: string;
+};
+
+export const DEFAULT_ARGS = {
+  /** Relative path to TypeScript config file */
+  p: 'tsconfig.json',
+  /**
+   * Option between only leaving comments ('comment') or both comments and
+   * mutative fixes ('all')
+   */
+  m: 'all',
+  _: [],
+  $0: '',
 };
 
 export type NodeDiagnostic = {

--- a/test/no_implicit_returns_test.ts
+++ b/test/no_implicit_returns_test.ts
@@ -62,7 +62,7 @@ describe('Runner', () => {
       /* parser */ undefined,
       errorDetector,
       [new NoImplicitReturnsManipulator(errorDetector)],
-      new OutOfPlaceEmitter(project, relativeOutputPath)
+      new OutOfPlaceEmitter(relativeOutputPath)
     ).run();
 
     const expectedOutputs = project.addSourceFilesAtPaths(

--- a/test/strict_null_checks_test.ts
+++ b/test/strict_null_checks_test.ts
@@ -65,7 +65,7 @@ describe('Runner', () => {
       /* parser */ undefined,
       errorDetector,
       [new StrictNullChecksManipulator(errorDetector)],
-      new OutOfPlaceEmitter(project, relativeOutputPath)
+      new OutOfPlaceEmitter(relativeOutputPath)
     ).run();
 
     const expectedOutputs = project.addSourceFilesAtPaths(


### PR DESCRIPTION
Fixes #15 

Before running the manipulators, this tool now first parses through the diagnostics outputted by the parser and ensures that the project compiles initially with all four flags set to false. Otherwise, throws and error and stops execution.

In order to re-use the same parser, we changed the order of the instantiation (creating Parser before verifying and creating the Project), and also moved the `project` argument from the constructor to the actual `parse` function. In my opinion, that makes more sense because a parser or emitter should be able to parse or emit multiple projects, and they aren't necessarily tied to one project.

Considerations:
- How to test? 