### PR TITLE
Refactor/comments v2

### DIFF
--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import {Diagnostic, ts} from 'ts-morph';
+import {Diagnostic, ts, Node} from 'ts-morph';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
 
 /** Base class for manipulating AST to fix for flags. */
@@ -45,5 +45,18 @@ export abstract class Manipulator {
    */
   hasErrors(diagnostics: Diagnostic<ts.Diagnostic>[]): boolean {
     return this.errorDetector.detectErrors(diagnostics, this.errorCodesToFix);
+  }
+
+  /**
+   * Verifies that a node hasn't been edited before by looking through leading comments and
+   * ensuring that comments weren't left by previous iterations of fixes.
+   * @param {Node<ts.Node>} node - Node to verify.
+   * @param {string} comment - Comment to look for when parsing leading comment ranges of node.
+   * @return {boolean} True if node hasn't been editted before.
+   */
+  verifyCommentRange(node: Node<ts.Node>, comment: string): boolean {
+    return !node.getLeadingCommentRanges().some(commentRange => {
+      return commentRange.getText().includes(comment);
+    });
   }
 }

--- a/src/manipulators/no_implicit_returns_manipulator.ts
+++ b/src/manipulators/no_implicit_returns_manipulator.ts
@@ -73,7 +73,11 @@ export class NoImplicitReturnsManipulator extends Manipulator {
 
         // When node is an empty return statement, replace it with return undefined.
         case SyntaxKind.ReturnStatement: {
-          if (parent && Node.isBlock(parent)) {
+          if (
+            parent &&
+            Node.isBlock(parent) &&
+            this.verifyCommentRange(errorNode, NO_IMPLICIT_RETURNS_COMMENT)
+          ) {
             const index = errorNode.getChildIndex();
             parent.removeStatement(index);
             this.addChildReturnStatement(parent);

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -541,7 +541,7 @@ export class StrictNullChecksManipulator extends Manipulator {
    * @param {string[]} types - List of types.
    * @return {string[]} List of filtered types.
    */
-  private filterUnnecessaryTypes(types: string[]): string[] {
+  filterUnnecessaryTypes(types: string[]): string[] {
     return types.filter((type, index) => {
       // If the current type contains "never" in a context and another type has the same
       // context without "never", the current type is not needed

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -166,7 +166,7 @@ export class StrictNullChecksManipulator extends Manipulator {
         ) {
           newDeclaration.replaceWithText(
             `${STRICT_NULL_CHECKS_COMMENT}\n${newDeclaration
-              .getFullText()
+              .getText()
               .trimLeft()}`
           );
         } else {
@@ -384,7 +384,7 @@ export class StrictNullChecksManipulator extends Manipulator {
       // Otherwise, add definite assignment assertion to the argument being passed
       // Eg. foo(n); -> foo(n!);
       if (!Node.isNonNullExpression(errorNode)) {
-        const newNode = errorNode.replaceWithText(errorNode.getText() + '!');
+        const newNode = errorNode.replaceWithText(`${errorNode.getText()}!`);
 
         const modifiedStatement = this.getModifiedStatement(newNode);
         if (modifiedStatement) {

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -239,10 +239,8 @@ export class StrictNullChecksManipulator extends Manipulator {
       diagnostic.getLength() === errorNode.getText().length
     ) {
       // Eg. foo.toString(); -> foo!.toString()
-      const newNode = errorNode.replaceWithText(errorNode.getText() + '!');
-
+      const newNode = errorNode.replaceWithText(`${errorNode.getText()}!`);
       const modifiedStatement = this.getModifiedStatement(newNode);
-
       this.addModifiedStatement(
         modifiedStatementedNodes,
         modifiedStatement as Statement

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -557,6 +557,7 @@ export class StrictNullChecksManipulator extends Manipulator {
       // If the current type contains "never" in a context and another type has the same
       // context without "never", the current type is not needed
       // Eg. never[] | string[] -> only string[] is needed
+      // Eg. { foo: never[] } | { foo: string[] } -> only { foo: string[] } is needed
       let startSearchNeverPos = 0;
       let matchNeverIndex: number;
       while (
@@ -564,6 +565,8 @@ export class StrictNullChecksManipulator extends Manipulator {
       ) {
         startSearchNeverPos = matchNeverIndex + 1;
         typeArray.forEach((otherType, otherIndex) => {
+          // If another type has matching beginnings and endings as the current type but
+          // doesn't have "never", include the other type but not this type
           if (
             otherIndex !== index &&
             otherType.startsWith(type.substring(0, matchNeverIndex)) &&
@@ -578,11 +581,14 @@ export class StrictNullChecksManipulator extends Manipulator {
       // If another type contains "any" in a context, and the current type has the same
       // context without "any", the current type is not needed
       // Eg. any[] | string[] -> only any[] is needed
+      // Eg. { foo: any[] } | { foo: string[] } -> only { foo: any[] } is needed
       let startSearchAnyPos = 0;
       let matchAnyIndex: number;
       while ((matchAnyIndex = type.indexOf('any', startSearchAnyPos)) !== -1) {
         startSearchAnyPos = matchAnyIndex + 1;
         typeArray.forEach((otherType, otherIndex) => {
+          // If other types have matching beginnings and endings as the current type but
+          // doesn't have "any", include this type and not the other types
           if (
             otherIndex !== index &&
             otherType.startsWith(type.substring(0, matchAnyIndex)) &&

--- a/test/strict_null_checks_test.ts
+++ b/test/strict_null_checks_test.ts
@@ -115,11 +115,12 @@ describe('StrictNullChecksManipulator', () => {
       {in: ['{foo: string[]}', '{foo: any[]}'], out: ['{foo: any[]}']},
       {in: ['{foo: never[]}', '{foo: string[]}'], out: ['{foo: string[]}']},
       {in: ['string', 'any'], out: ['any']},
+      {in: ['null', 'any[]'], out: ['null', 'any[]']},
     ];
 
     for (let typeList of typeLists) {
-      expect(manipulator.filterUnnecessaryTypes(typeList.in)).toEqual(
-        typeList.out
+      expect(manipulator.filterUnnecessaryTypes(new Set(typeList.in))).toEqual(
+        new Set(typeList.out)
       );
     }
   });

--- a/test/strict_null_checks_test.ts
+++ b/test/strict_null_checks_test.ts
@@ -15,68 +15,112 @@
 */
 
 import {Project} from 'ts-morph';
-import {Runner} from 'src/runner';
-import {OutOfPlaceEmitter} from 'src/emitters/out_of_place_emitter';
-import {SourceFileComparer} from 'testing/source_file_matcher';
+import {Runner} from '@/src/runner';
+import {OutOfPlaceEmitter} from '@/src/emitters/out_of_place_emitter';
+import {SourceFileComparer} from '@/testing/source_file_matcher';
 import {ProdErrorDetector} from '@/src/error_detectors/prod_error_detector';
 import {StrictNullChecksManipulator} from '@/src/manipulators/strict_null_checks_manipulator';
+import {ErrorDetector} from '@/src/error_detectors/error_detector';
+import {Emitter} from '@/src/emitters/emitter';
 
-describe('Runner', () => {
+describe('StrictNullChecksManipulator', () => {
+  let project: Project;
+  let errorDetector: ErrorDetector;
+  let emitter: Emitter;
+  let manipulator: StrictNullChecksManipulator;
+
   beforeAll(() => {
     jasmine.addMatchers(SourceFileComparer);
-  });
 
-  it('should fix strictNullChecks', () => {
     const relativeOutputPath = './ts_upgrade';
     const inputConfigPath = './test/test_files/tsconfig.json';
 
-    const inputFilePaths = [
-      './test/test_files/strict_null_checks/object_possibly_null.ts',
-      './test/test_files/strict_null_checks/unassignable_argument_type.ts',
-      './test/test_files/strict_null_checks/unassignable_variable_type.ts',
-    ];
-    const actualOutputFilePaths = [
-      './test/test_files/strict_null_checks/ts_upgrade/object_possibly_null.ts',
-      './test/test_files/strict_null_checks/ts_upgrade/unassignable_argument_type.ts',
-      './test/test_files/strict_null_checks/ts_upgrade/unassignable_variable_type.ts',
-    ];
-    const expectedOutputFilePaths = [
-      './test/test_files/golden/strict_null_checks/object_possibly_null.ts',
-      './test/test_files/golden/strict_null_checks/unassignable_argument_type.ts',
-      './test/test_files/golden/strict_null_checks/unassignable_variable_type.ts',
-    ];
-
-    const project = new Project({
+    project = new Project({
       tsConfigFilePath: inputConfigPath,
       addFilesFromTsConfig: false,
       compilerOptions: {
         strictNullChecks: true,
       },
     });
+    errorDetector = new ProdErrorDetector();
+    emitter = new OutOfPlaceEmitter(relativeOutputPath);
+    manipulator = new StrictNullChecksManipulator(errorDetector);
+  });
 
-    project.addSourceFilesAtPaths(inputFilePaths);
-    project.resolveSourceFileDependencies();
+  const testFiles = [
+    {
+      description: 'fixes when object is possibly null or undefined',
+      inputFilePath:
+        './test/test_files/strict_null_checks/object_possibly_null.ts',
+      actualOutputFilePath:
+        './test/test_files/strict_null_checks/ts_upgrade/object_possibly_null.ts',
+      expectedOutputFilePath:
+        './test/test_files/golden/strict_null_checks/object_possibly_null.ts',
+    },
+    {
+      description: 'fixes when argument with unassignable type is passeds',
+      inputFilePath:
+        './test/test_files/strict_null_checks/unassignable_argument_type.ts',
+      actualOutputFilePath:
+        './test/test_files/strict_null_checks/ts_upgrade/unassignable_argument_type.ts',
+      expectedOutputFilePath:
+        './test/test_files/golden/strict_null_checks/unassignable_argument_type.ts',
+    },
+    {
+      description: 'fixes when a variable is assigned an unassignable types',
+      inputFilePath:
+        './test/test_files/strict_null_checks/unassignable_variable_type.ts',
+      actualOutputFilePath:
+        './test/test_files/strict_null_checks/ts_upgrade/unassignable_variable_type.ts',
+      expectedOutputFilePath:
+        './test/test_files/golden/strict_null_checks/unassignable_variable_type.ts',
+    },
+  ];
 
-    const errorDetector = new ProdErrorDetector();
+  for (let test of testFiles) {
+    it(test.description, () => {
+      const input = project.addSourceFileAtPath(test.inputFilePath);
+      project.resolveSourceFileDependencies();
 
-    new Runner(
-      /* args*/ undefined,
-      project,
-      /* parser */ undefined,
-      errorDetector,
-      [new StrictNullChecksManipulator(errorDetector)],
-      new OutOfPlaceEmitter(relativeOutputPath)
-    ).run();
+      new Runner(
+        /* args*/ undefined,
+        project,
+        /* parser */ undefined,
+        errorDetector,
+        [manipulator],
+        emitter
+      ).run();
 
-    const expectedOutputs = project.addSourceFilesAtPaths(
-      expectedOutputFilePaths
-    );
-    const actualOutputs = project.addSourceFilesAtPaths(actualOutputFilePaths);
+      const expectedOutput = project.addSourceFileAtPath(
+        test.expectedOutputFilePath
+      );
+      const actualOutput = project.addSourceFileAtPath(
+        test.actualOutputFilePath
+      );
 
-    expect(expectedOutputs.length).toEqual(actualOutputs.length);
+      expect(actualOutput).toHaveSameASTAs(expectedOutput);
 
-    for (let i = 0; i < actualOutputs.length; i++) {
-      expect(actualOutputs[i]).toHaveSameASTAs(expectedOutputs[i]);
+      project.removeSourceFile(input);
+      project.removeSourceFile(actualOutput);
+      project.removeSourceFile(expectedOutput);
+    });
+  }
+
+  it('correctly filters unnecessary types', () => {
+    const typeLists = [
+      {in: [], out: []},
+      {in: ['string[]'], out: ['string[]']},
+      {in: ['string[]', 'any[]'], out: ['any[]']},
+      {in: ['never[]', 'string[]'], out: ['string[]']},
+      {in: ['{foo: string[]}', '{foo: any[]}'], out: ['{foo: any[]}']},
+      {in: ['{foo: never[]}', '{foo: string[]}'], out: ['{foo: string[]}']},
+      {in: ['string', 'any'], out: ['any']},
+    ];
+
+    for (let typeList of typeLists) {
+      expect(manipulator.filterUnnecessaryTypes(typeList.in)).toEqual(
+        typeList.out
+      );
     }
   });
 });

--- a/test/strict_null_checks_test.ts
+++ b/test/strict_null_checks_test.ts
@@ -58,7 +58,7 @@ describe('StrictNullChecksManipulator', () => {
         './test/test_files/golden/strict_null_checks/object_possibly_null.ts',
     },
     {
-      description: 'fixes when argument with unassignable type is passeds',
+      description: 'fixes when argument with unassignable type is passed',
       inputFilePath:
         './test/test_files/strict_null_checks/unassignable_argument_type.ts',
       actualOutputFilePath:

--- a/test/test_files/golden/strict_null_checks/unassignable_variable_type.ts
+++ b/test/test_files/golden/strict_null_checks/unassignable_variable_type.ts
@@ -1,9 +1,10 @@
 interface BasicInterface {}
-// typescript-flag-upgrade automated fix: --strictNullChecks
 
 class StrictNullChecksSample {
   // Test: Assign class member to null/undefined
+  // typescript-flag-upgrade automated fix: --strictNullChecks
   shouldBeNumber: null | number;
+  // typescript-flag-upgrade automated fix: --strictNullChecks
   shouldBeInterface: BasicInterface | undefined;
 
   constructor() {


### PR DESCRIPTION
Fixes #18 and also refactors more of the functionality for leaving comments.

3 main fixes/changes:

1. Before, the tool would place the `//typescript-flag-upgrade automatic fix` comment in the wrong location for property declarations, outputting the following:
```
//typescript-flag-upgrade automatic fix
class BasicClass {
   foo: number | undefined; <- this line was modified
}
```

Now, the tool places the comment in the right place, right before the property declaration:
```
class BasicClass {
   //typescript-flag-upgrade automatic fix
   foo: number | undefined; <- this line was modified
}
```

2. Before, in the strictNullChecks manipulator, the tool automatically removes array types when the `any[]` type is explicitly written, and removes all types when the `any` type is explicitly written. However, these cases were hardcoded in before, so this fix expands the functionality of filtering unnecessary types using string processing instead of hardcoded checks.

3. I realized that every manipulator will need to have the functionality of being able to check if a node has been modified before (to prevent an infinite loop of the same changes again and again), so I created a function to do this and moved it into the general `Manipulator` class.