### PR TITLE
Implement NoImplicitAnyManipulator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -516,7 +516,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1343,8 +1342,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -2535,7 +2533,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
       "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/googleinterns/typescript-flag-upgrade#readme",
   "dependencies": {
+    "chalk": "^4.1.0",
     "lodash": "^4.17.19",
     "path": "^0.12.7",
     "ts-morph": "^7.1.1",

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -135,7 +135,11 @@ export abstract class Manipulator {
    * @param {Type<ts.Type>} type - Type to be converted to a string.
    * @return {string[]} String representation of type.
    */
-  typeToString(type: Type<ts.Type>, enclosingNode?: Node<ts.Node>): string[] {
+  typeToString(type?: Type<ts.Type>, enclosingNode?: Node<ts.Node>): string[] {
+    if (!type) {
+      return [];
+    }
+
     return this.toTypeList(type).map(subType =>
       subType.getText(
         enclosingNode,

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import {Diagnostic, ts, Node} from 'ts-morph';
+import {Diagnostic, ts, Node, Type} from 'ts-morph';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 
 /** Base class for manipulating AST to fix for flags. */
@@ -75,5 +75,18 @@ export abstract class Manipulator {
         new Set<V>([val])
       );
     }
+  }
+
+  /**
+   * Converts a Union type into a list of base types, if applicable.
+   * @param {Type} type - Input type.
+   * @return {Type[]} List of types represented by input type.
+   */
+  toTypeList(type: Type): Type[] {
+    return type.isUnion()
+      ? type.getUnionTypes().map(individualType => {
+          return individualType.getBaseTypeOfLiteralType();
+        })
+      : [type.getBaseTypeOfLiteralType()];
   }
 }

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -14,7 +14,7 @@
     limitations under the License.
 */
 
-import {Diagnostic, ts, Node, Type} from 'ts-morph';
+import {Diagnostic, ts, Node, Type, Statement} from 'ts-morph';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 
 /** Base class for manipulating AST to fix for flags. */
@@ -88,5 +88,16 @@ export abstract class Manipulator {
           return individualType.getBaseTypeOfLiteralType();
         })
       : [type.getBaseTypeOfLiteralType()];
+  }
+
+  /**
+   * Traverses through a node's ancestor and returns the closest Statement node.
+   * @param {Node<ts.Node>} node - Modified node.
+   * @return {Statement|undefined} Closest Statement ancestor of modified node or undefined if doesn't exist.
+   */
+  getModifiedStatement(node: Node<ts.Node>): Statement | undefined {
+    return node.getParentWhile((parent, child) => {
+      return !(Node.isStatementedNode(parent) && Node.isStatement(child));
+    }) as Statement;
   }
 }

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -59,4 +59,21 @@ export abstract class Manipulator {
       return commentRange.getText().includes(comment);
     });
   }
+
+  /**
+   * Adds value to a Map with Set value types.
+   * @param {Map<K, Set<V>>} map - Map to add to.
+   * @param {K} key - Key to insert value at.
+   * @param {V} val - Value to insert.
+   */
+  addToMapSet<K, V>(map: Map<K, Set<V>>, key: K, val: V): void {
+    if (map.has(key)) {
+      map.get(key)?.add(val);
+    } else {
+      map.set(
+        key,
+        new Set<V>([val])
+      );
+    }
+  }
 }

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -91,13 +91,17 @@ export abstract class Manipulator {
   }
 
   /**
-   * Traverses through a node's ancestor and returns the closest Statement node.
+   * Returns a modified node's closest Statement ancestor, or the node itself if it is Statement.
    * @param {Node<ts.Node>} node - Modified node.
    * @return {Statement|undefined} Closest Statement ancestor of modified node or undefined if doesn't exist.
    */
   getModifiedStatement(node: Node<ts.Node>): Statement | undefined {
+    if (Node.isStatement(node)) {
+      return node;
+    }
+
     return node.getParentWhile((parent, child) => {
       return !(Node.isStatementedNode(parent) && Node.isStatement(child));
-    }) as Statement;
+    }) as Statement | undefined;
   }
 }

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -67,14 +67,12 @@ export abstract class Manipulator {
    * @param {V} val - Value to insert.
    */
   addToMapSet<K, V>(map: Map<K, Set<V>>, key: K, val: V): void {
-    if (map.has(key)) {
-      map.get(key)?.add(val);
-    } else {
-      map.set(
-        key,
-        new Set<V>([val])
-      );
+    let values: Set<V> | undefined = map.get(key);
+    if (!values) {
+      values = new Set<V>();
+      map.set(key, values);
     }
+    values.add(val);
   }
 
   /**

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -24,7 +24,6 @@ import {
   ParameterDeclaration,
 } from 'ts-morph';
 import chalk from 'chalk';
-import _ from 'lodash';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
 import {ErrorCodes, NO_IMPLICIT_ANY_COMMENT, NodeDiagnostic} from '@/src/types';
 
@@ -386,7 +385,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
     >
   ) {
     // Calculate all descendant dependencies (direct and indirect) for every declaration.
-    const descendantDeclarationDependencies = this.calculateDescendantDependencies(
+    const descendantDeclarationDependencies = this.calculateDescendants(
       new Set(sortedDeclarations),
       directDeclarationDependencies
     );
@@ -462,11 +461,11 @@ export class NoImplicitAnyManipulator extends Manipulator {
    * @param {Map<T, Set<T>>} edges - Map of directed edges between vertices.
    * @return {Map<T, Set<T>>} Map of vertex to set of descendant vertices with a path from the vertex.
    */
-  private calculateDescendantDependencies<T>(
+  private calculateDescendants<T>(
     vertices: Set<T>,
     edges: Map<T, Set<T>>
   ): Map<T, Set<T>> {
-    const descendantDependencies = new Map<T, Set<T>>();
+    const descendants = new Map<T, Set<T>>();
 
     vertices.forEach(vertex => {
       const visitedVertices = new Set<T>();
@@ -475,10 +474,10 @@ export class NoImplicitAnyManipulator extends Manipulator {
       this.postOrderRecurse(vertex, visitedVertices, vertexDescendants, edges);
       vertexDescendants.pop();
 
-      descendantDependencies.set(vertex, new Set(vertexDescendants));
+      descendants.set(vertex, new Set(vertexDescendants));
     });
 
-    return descendantDependencies;
+    return descendants;
   }
 
   /**

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -239,19 +239,11 @@ export class NoImplicitAnyManipulator extends Manipulator {
     modifiedDeclarations: Set<AcceptedDeclaration>
   ): void {
     // If declaration has an initialized value, add its type to the calculated declaration types.
-    const initializedValue = declaration.getInitializer();
-    const initializedType = initializedValue
-      ? this.toTypeList(initializedValue.getType())
-      : undefined;
-    if (initializedType) {
-      initializedType.forEach(type => {
-        this.addMultipleToMapSet(
-          calculatedDeclarationTypes,
-          declaration,
-          this.typeToString(type, declaration)
-        );
-      });
-    }
+    this.addMultipleToMapSet(
+      calculatedDeclarationTypes,
+      declaration,
+      this.typeToString(declaration.getInitializer()?.getType(), declaration)
+    );
 
     // Find for all assignment references for declaration.
     declaration.findReferencesAsNodes()?.forEach(reference => {
@@ -330,14 +322,11 @@ export class NoImplicitAnyManipulator extends Manipulator {
       });
     } else {
       // Otherwise, get predecessor's type and add it to the calculated declaration type of the successor.
-      const calculatedType = this.toTypeList(predecessorNode.getType());
-      calculatedType.forEach(type => {
-        this.addMultipleToMapSet(
-          calculatedDeclarationTypes,
-          successorDeclaration,
-          this.typeToString(type, predecessorNode)
-        );
-      });
+      this.addMultipleToMapSet(
+        calculatedDeclarationTypes,
+        successorDeclaration,
+        this.typeToString(predecessorNode.getType(), predecessorNode)
+      );
     }
   }
 

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -172,7 +172,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
    * @param {Map<AcceptedDeclaration, Set<string>>} calculatedDeclarationTypes - Calculated types for each declaration.
    * @param {Set<AcceptedDeclaration>} modifiedDeclarations - Set of modified declarations (vertices).
    */
-  private addFunctionCallDeclarationDependencies(
+  addFunctionCallDeclarationDependencies(
     declaration: ParameterDeclaration,
     directDeclarationDependencies: Map<
       AcceptedDeclaration,
@@ -229,7 +229,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
    * @param {Map<AcceptedDeclaration, Set<string>>} calculatedDeclarationTypes - Calculated types for each declaration.
    * @param {Set<AcceptedDeclaration>} modifiedDeclarations - Set of modified declarations (vertices).
    */
-  private addAssignmentDeclarationDependencies(
+  addAssignmentDeclarationDependencies(
     declaration: AcceptedDeclaration,
     directDeclarationDependencies: Map<
       AcceptedDeclaration,
@@ -347,7 +347,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
    * @param {AcceptedDeclaration[]} sortedDeclarations - Topologically sorted list of declarations.
    * @param {Map<AcceptedDeclaration, Set<AcceptedDeclaration>>} directDeclarationDependencies - Direct dependency graph between declarations.
    */
-  private calculateDeclarationTypes(
+  calculateDeclarationTypes(
     calculatedDeclarationTypes: Map<AcceptedDeclaration, Set<string>>,
     sortedDeclarations: AcceptedDeclaration[],
     directDeclarationDependencies: Map<
@@ -473,6 +473,31 @@ export class NoImplicitAnyManipulator extends Manipulator {
   }
 
   /**
+   * Given a directed graph, constructs a map of vertex to set of descendant vertices with a path from the vertex.
+   * @param {Set<T>} vertices - Set of vertices.
+   * @param {Map<T, Set<T>>} edges - Map of directed edges between vertices.
+   * @return {Map<T, Set<T>>} Map of vertex to set of descendant vertices with a path from the vertex.
+   */
+  calculateDescendants<T>(
+    vertices: Set<T>,
+    edges: Map<T, Set<T>>
+  ): Map<T, Set<T>> {
+    const descendants = new Map<T, Set<T>>();
+
+    vertices.forEach(vertex => {
+      const visitedVertices = new Set<T>();
+      const vertexDescendants: T[] = [];
+
+      this.postOrderRecurse(vertex, visitedVertices, vertexDescendants, edges);
+      vertexDescendants.pop();
+
+      descendants.set(vertex, new Set(vertexDescendants));
+    });
+
+    return descendants;
+  }
+
+  /**
    * Recursively constructs the postorder depth-first traversal.
    * @param {T} vertex - Current vertex.
    * @param {Set<T>} visitedVertices - Set of visited vertices.
@@ -492,30 +517,5 @@ export class NoImplicitAnyManipulator extends Manipulator {
       }
     });
     postOrder.push(vertex);
-  }
-
-  /**
-   * Given a directed graph, constructs a map of vertex to set of descendant vertices with a path from the vertex.
-   * @param {Set<T>} vertices - Set of vertices.
-   * @param {Map<T, Set<T>>} edges - Map of directed edges between vertices.
-   * @return {Map<T, Set<T>>} Map of vertex to set of descendant vertices with a path from the vertex.
-   */
-  private calculateDescendants<T>(
-    vertices: Set<T>,
-    edges: Map<T, Set<T>>
-  ): Map<T, Set<T>> {
-    const descendants = new Map<T, Set<T>>();
-
-    vertices.forEach(vertex => {
-      const visitedVertices = new Set<T>();
-      const vertexDescendants: T[] = [];
-
-      this.postOrderRecurse(vertex, visitedVertices, vertexDescendants, edges);
-      vertexDescendants.pop();
-
-      descendants.set(vertex, new Set(vertexDescendants));
-    });
-
-    return descendants;
   }
 }

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -25,7 +25,7 @@ import {
   ParameterDeclaration,
 } from 'ts-morph';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
-import {ErrorCodes, NO_IMPLICIT_ANY_COMMENT} from '../types';
+import {ErrorCodes, NO_IMPLICIT_ANY_COMMENT} from '@/src/types';
 
 type AcceptedDeclaration = VariableDeclaration | ParameterDeclaration;
 

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -20,13 +20,12 @@ import {
   ts,
   SyntaxKind,
   Node,
-  VariableDeclaration,
   Type,
+  VariableDeclaration,
   ParameterDeclaration,
 } from 'ts-morph';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
 import {ErrorCodes} from '../types';
-import {Declaration} from 'typescript';
 
 /**
  * Manipulator that fixes for the noImplicitAny compiler flag.
@@ -58,9 +57,8 @@ export class NoImplicitAnyManipulator extends Manipulator {
       this.nodeKinds
     );
 
-    const modifiedDeclarations = new Set<
-      VariableDeclaration | ParameterDeclaration
-    >();
+    type AcceptedDeclaration = VariableDeclaration | ParameterDeclaration;
+    const modifiedDeclarations = new Set<AcceptedDeclaration>();
 
     // Iterate through each node in reverse traversal order to prevent interference.
     errorNodes.forEach(({node: errorNode}) => {
@@ -78,13 +76,10 @@ export class NoImplicitAnyManipulator extends Manipulator {
       }
     });
 
-    const determinedTypes = new Map<
-      VariableDeclaration | ParameterDeclaration,
-      Set<Type>
-    >();
+    const determinedTypes = new Map<AcceptedDeclaration, Set<Type>>();
     const dependencyGraph = new Map<
-      VariableDeclaration | ParameterDeclaration,
-      Set<VariableDeclaration | ParameterDeclaration>
+      AcceptedDeclaration,
+      Set<AcceptedDeclaration>
     >();
 
     modifiedDeclarations.forEach(declaration => {

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -24,6 +24,7 @@ import {
   VariableDeclaration,
   ParameterDeclaration,
 } from 'ts-morph';
+import chalk from 'chalk';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
 import {ErrorCodes, NO_IMPLICIT_ANY_COMMENT, NodeDiagnostic} from '@/src/types';
 
@@ -302,10 +303,16 @@ export class NoImplicitAnyManipulator extends Manipulator {
 
       // If declaration has type any, output to user and skip successors.
       if (!calculatedDeclarationTypes.has(declaration)) {
+        // TODO: Move console log funcionality to a logger class.
         console.log(
-          `${declaration
-            .getSourceFile()
-            .getFilePath()}:${declaration.getStartLineNumber()}:${declaration.getStartLinePos()}:${declaration.getText()} - Unable to automatically calculate type.`
+          chalk.cyan(`${declaration.getSourceFile().getFilePath()}`) +
+            ':' +
+            chalk.yellow(`${declaration.getStartLineNumber()}`) +
+            ':' +
+            chalk.yellow(`${declaration.getStartLinePos()}`) +
+            ' - ' +
+            chalk.red('error') +
+            `: Unable to automatically calculate type of '${declaration.getText()}'.`
         );
         dependencyGraph
           .get(declaration)

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -394,8 +394,8 @@ export class NoImplicitAnyManipulator extends Manipulator {
       Set<AcceptedDeclaration>
     >
   ) {
-    // Calculate all descendent dependencies (direct and indirect) for every declaration.
-    const descendentDeclarationDependencies = this.calculateDescendentDependencies(
+    // Calculate all descendant dependencies (direct and indirect) for every declaration.
+    const descendantDeclarationDependencies = this.calculateDescendantDependencies(
       new Set(sortedDeclarations),
       directDeclarationDependencies
     );
@@ -405,15 +405,15 @@ export class NoImplicitAnyManipulator extends Manipulator {
     const skipDeclarations = new Set<AcceptedDeclaration>();
 
     sortedDeclarations.forEach(declaration => {
-      // If declaration is skipped, also skip its descendents.
+      // If declaration is skipped, also skip its descendants.
       if (skipDeclarations.has(declaration)) {
-        descendentDeclarationDependencies
+        descendantDeclarationDependencies
           .get(declaration)
-          ?.forEach(descendent => skipDeclarations.add(descendent));
+          ?.forEach(descendant => skipDeclarations.add(descendant));
         return;
       }
 
-      // If declaration has type any, log to user and skip descendents.
+      // If declaration has type any, log to user and skip descendants.
       if (
         !calculatedDeclarationTypes.has(declaration) ||
         ![...calculatedDeclarationTypes.get(declaration)!].every(type =>
@@ -430,34 +430,34 @@ export class NoImplicitAnyManipulator extends Manipulator {
             ' - ' +
             chalk.red('error') +
             `: Unable to automatically calculate type of '${declaration.getText()}'. This declaration also affects ${
-              descendentDeclarationDependencies.get(declaration)?.size || 0
+              descendantDeclarationDependencies.get(declaration)?.size || 0
             } other declarations.`
         );
 
         // Remove declaration and descendants from calculatedDeclarationTypes.
         calculatedDeclarationTypes.delete(declaration);
-        descendentDeclarationDependencies
+        descendantDeclarationDependencies
           .get(declaration)
-          ?.forEach(descendent => {
-            if (!calculatedDeclarationTypes.has(descendent)) {
-              skipDeclarations.add(descendent);
+          ?.forEach(descendant => {
+            if (!calculatedDeclarationTypes.has(descendant)) {
+              skipDeclarations.add(descendant);
             }
-            calculatedDeclarationTypes.delete(descendent);
+            calculatedDeclarationTypes.delete(descendant);
           });
 
         return;
       }
 
-      // If declaration has determined type, also give descendents the calculated type.
-      descendentDeclarationDependencies
+      // If declaration has determined type, also give descendants the calculated type.
+      descendantDeclarationDependencies
         .get(declaration)
-        ?.forEach(descendent => {
+        ?.forEach(descendant => {
           calculatedDeclarationTypes
             .get(declaration)!
             .forEach(calculatedType => {
               this.addToMapSet(
                 calculatedDeclarationTypes,
-                descendent,
+                descendant,
                 calculatedType
               );
             });
@@ -489,28 +489,28 @@ export class NoImplicitAnyManipulator extends Manipulator {
   }
 
   /**
-   * Given a directed graph, constructs a map of vertex to set of descendent vertices with a path from the vertex.
+   * Given a directed graph, constructs a map of vertex to set of descendant vertices with a path from the vertex.
    * @param {Set<T>} vertices - Set of vertices.
    * @param {Map<T, Set<T>>} edges - Map of directed edges between vertices.
-   * @return {Map<T, Set<T>>} Map of vertex to set of descendent vertices with a path from the vertex.
+   * @return {Map<T, Set<T>>} Map of vertex to set of descendant vertices with a path from the vertex.
    */
-  private calculateDescendentDependencies<T>(
+  private calculateDescendantDependencies<T>(
     vertices: Set<T>,
     edges: Map<T, Set<T>>
   ): Map<T, Set<T>> {
-    const descendentDependencies = new Map<T, Set<T>>();
+    const descendantDependencies = new Map<T, Set<T>>();
 
     vertices.forEach(vertex => {
       const visitedVertices = new Set<T>();
-      const vertexDescendents: T[] = [];
+      const vertexDescendants: T[] = [];
 
-      this.postOrderRecurse(vertex, visitedVertices, vertexDescendents, edges);
-      vertexDescendents.pop();
+      this.postOrderRecurse(vertex, visitedVertices, vertexDescendants, edges);
+      vertexDescendants.pop();
 
-      descendentDependencies.set(vertex, new Set(vertexDescendents));
+      descendantDependencies.set(vertex, new Set(vertexDescendants));
     });
 
-    return descendentDependencies;
+    return descendantDependencies;
   }
 
   /**

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -207,17 +207,24 @@ export class NoImplicitAnyManipulator extends Manipulator {
   ) {
     const references = declaration.findReferencesAsNodes();
     references?.forEach(reference => {
-      const parent = reference.getParentIfKind(SyntaxKind.BinaryExpression);
-      const sibling = reference.getNextSiblingIfKind(SyntaxKind.EqualsToken);
-      const nextSibling = sibling?.getNextSibling();
+      const binaryExpressionNode = reference.getParentIfKind(
+        SyntaxKind.BinaryExpression
+      );
+      const variableBeingAssigned = binaryExpressionNode?.getLeft();
+      const binaryExpressionOperator = binaryExpressionNode?.getOperatorToken();
+      const assignedValueExpression = binaryExpressionNode?.getRight();
 
       // Add assigned value's declaration to the dependency graph
-      if (parent && nextSibling) {
+      if (
+        reference === variableBeingAssigned &&
+        binaryExpressionOperator?.getKind() === SyntaxKind.EqualsToken &&
+        assignedValueExpression
+      ) {
         this.addDependency(
           dependencyGraph,
           determinedTypes,
           modifiedDeclarations,
-          nextSibling,
+          assignedValueExpression,
           declaration
         );
       }

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -380,7 +380,10 @@ export class StrictNullChecksManipulator extends Manipulator {
 
       // Otherwise, add definite assignment assertion to the argument being passed
       // Eg. foo(n); -> foo(n!);
-      if (!Node.isNonNullExpression(errorNode)) {
+      if (
+        !Node.isNonNullExpression(errorNode) &&
+        !errorNode.getText().endsWith('!')
+      ) {
         const newNode = errorNode.replaceWithText(`${errorNode.getText()}!`);
 
         const modifiedStatement = this.getModifiedStatement(newNode);

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -417,17 +417,6 @@ export class StrictNullChecksManipulator extends Manipulator {
   }
 
   /**
-   * Traverses through a node's ancestor and returns the closest Statement node.
-   * @param {Node<ts.Node>} node - Modified node.
-   * @return {Statement|undefined} Closest Statement ancestor of modified node or undefined if doesn't exist.
-   */
-  private getModifiedStatement(node: Node<ts.Node>): Statement | undefined {
-    return node.getParentWhile((parent, child) => {
-      return !(Node.isStatementedNode(parent) && Node.isStatement(child));
-    }) as Statement;
-  }
-
-  /**
    * Returns list of array declarations with type never[].
    * @param {SourceFile} sourceFile - Source file to search through.
    * @return {Set<Node<ts.Node>>} Set of array declarations with type never[].

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -520,23 +520,6 @@ export class StrictNullChecksManipulator extends Manipulator {
   }
 
   /**
-   * Adds value to a Map with Set value types.
-   * @param {Map<K, Set<V>>} map - Map to add to.
-   * @param {K} key - Key to insert value at.
-   * @param {V} val - Value to insert.
-   */
-  private addToMapSet<K, V>(map: Map<K, Set<V>>, key: K, val: V): void {
-    if (map.has(key)) {
-      map.get(key)?.add(val);
-    } else {
-      map.set(
-        key,
-        new Set<V>([val])
-      );
-    }
-  }
-
-  /**
    * Parses through a list of types and removes unnecessary types caused by any and never.
    * @param {string[]} types - List of types.
    * @return {string[]} List of filtered types.

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -417,19 +417,6 @@ export class StrictNullChecksManipulator extends Manipulator {
   }
 
   /**
-   * Converts a Union type into a list of base types, if applicable.
-   * @param {Type} type - Input type.
-   * @return {Type[]} List of types represented by input type.
-   */
-  private toTypeList(type: Type): Type[] {
-    return type.isUnion()
-      ? type.getUnionTypes().map(individualType => {
-          return individualType.getBaseTypeOfLiteralType();
-        })
-      : [type.getBaseTypeOfLiteralType()];
-  }
-
-  /**
    * Traverses through a node's ancestor and returns the closest Statement node.
    * @param {Node<ts.Node>} node - Modified node.
    * @return {Statement|undefined} Closest Statement ancestor of modified node or undefined if doesn't exist.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -69,9 +69,9 @@ export class Runner {
     this.errorDetector = errorDetector || new ProdErrorDetector();
     this.manipulators = manipulators || [
       new NoImplicitReturnsManipulator(this.errorDetector),
-      new NoImplicitAnyManipulator(this.errorDetector),
       new StrictPropertyInitializationManipulator(this.errorDetector),
       new StrictNullChecksManipulator(this.errorDetector),
+      new NoImplicitAnyManipulator(this.errorDetector),
     ];
     this.emitter = emitter || new InPlaceEmitter();
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -107,6 +107,7 @@ export class Runner {
           errorsExist = true;
           prevErrors = errors;
           errors = this.parser.parse(this.project);
+          break;
         }
       }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -69,9 +69,9 @@ export class Runner {
     this.errorDetector = errorDetector || new ProdErrorDetector();
     this.manipulators = manipulators || [
       new NoImplicitReturnsManipulator(this.errorDetector),
+      new NoImplicitAnyManipulator(this.errorDetector),
       new StrictPropertyInitializationManipulator(this.errorDetector),
       new StrictNullChecksManipulator(this.errorDetector),
-      new NoImplicitAnyManipulator(this.errorDetector),
     ];
     this.emitter = emitter || new InPlaceEmitter();
   }
@@ -107,7 +107,6 @@ export class Runner {
           errorsExist = true;
           prevErrors = errors;
           errors = this.parser.parse(this.project);
-          break;
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,8 @@ export enum ErrorCodes {
   ArgumentNotAssignableToParameter = 2345,
   NoOverloadMatches = 2769,
   PropertyNoInitializer = 2564,
-  TypeImplicitlyAny = 7005,
+  VariableImplicitlyAny = 7005,
+  ParameterImplicitlyAny = 7006,
 }
 
 export type DeclarationType = Map<

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,7 @@ export enum ErrorCodes {
   ArgumentNotAssignableToParameter = 2345,
   NoOverloadMatches = 2769,
   PropertyNoInitializer = 2564,
+  TypeImplicitlyAny = 7005,
 }
 
 export type DeclarationType = Map<

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,3 +88,5 @@ export const NO_IMPLICIT_RETURNS_COMMENT =
   '// typescript-flag-upgrade automated fix: --noImplicitReturns';
 export const STRICT_PROPERTY_INITIALIZATION_COMMENT =
   '// typescript-flag-upgrade automated fix: --strictPropertyInitialization';
+export const NO_IMPLICIT_ANY_COMMENT =
+  '// typescript-flag-upgrade automated fix: --noImplicitAny';

--- a/test/no_implicit_any_test.ts
+++ b/test/no_implicit_any_test.ts
@@ -101,6 +101,7 @@ describe('NoImplicitAnyManipulator', () => {
 
   it('topologically sorts graph', () => {
     const graphs = [
+      // Basic graph
       {
         vertices: new Set(['x', 'y', 'z', 'w']),
         edges: new Map([
@@ -112,6 +113,7 @@ describe('NoImplicitAnyManipulator', () => {
           ['x', 'y', 'w', 'z'],
         ],
       },
+      // Cyclical graph
       {
         vertices: new Set(['x', 'y', 'z', 'w']),
         edges: new Map([
@@ -138,6 +140,7 @@ describe('NoImplicitAnyManipulator', () => {
 
   it('constructs descendants map', () => {
     const graphs = [
+      // Basic graph
       {
         vertices: new Set(['x', 'y', 'z', 'w']),
         edges: new Map([
@@ -151,6 +154,7 @@ describe('NoImplicitAnyManipulator', () => {
           ['w', new Set()],
         ]),
       },
+      // Cyclical graph
       {
         vertices: new Set(['x', 'y', 'z', 'w']),
         edges: new Map([

--- a/test/no_implicit_any_test.ts
+++ b/test/no_implicit_any_test.ts
@@ -30,7 +30,7 @@ describe('NoImplicitAnyManipulator', () => {
   let emitter: Emitter;
   let manipulator: NoImplicitAnyManipulator;
 
-  beforeAll(() => {
+  beforeEach(() => {
     jasmine.addMatchers(SourceFileComparer);
 
     const relativeOutputPath = './ts_upgrade';
@@ -100,43 +100,322 @@ describe('NoImplicitAnyManipulator', () => {
   }
 
   it('topologically sorts graph', () => {
-    const basicGraph = {
-      vertices: new Set(['x', 'y', 'z', 'w']),
-      edges: new Map([
-        ['x', new Set(['y', 'z'])],
-        ['y', new Set(['z', 'w'])],
-      ]),
-      sorted: [
-        ['x', 'y', 'z', 'w'],
-        ['x', 'y', 'w', 'z'],
-      ],
-    };
+    const graphs = [
+      {
+        vertices: new Set(['x', 'y', 'z', 'w']),
+        edges: new Map([
+          ['x', new Set(['y', 'z'])],
+          ['y', new Set(['z', 'w'])],
+        ]),
+        output: [
+          ['x', 'y', 'z', 'w'],
+          ['x', 'y', 'w', 'z'],
+        ],
+      },
+      {
+        vertices: new Set(['x', 'y', 'z', 'w']),
+        edges: new Map([
+          ['x', new Set(['y'])],
+          ['y', new Set(['z'])],
+          ['z', new Set(['w'])],
+          ['w', new Set(['y'])],
+        ]),
+        output: [['x', 'y', 'z', 'w']],
+      },
+    ];
+
+    for (const graph of graphs) {
+      expect(
+        graph.output.some(expectedOut =>
+          _.isEqual(
+            manipulator.topoSort(graph.vertices, graph.edges),
+            expectedOut
+          )
+        )
+      ).toBeTrue();
+    }
+  });
+
+  it('constructs descendants map', () => {
+    const graphs = [
+      {
+        vertices: new Set(['x', 'y', 'z', 'w']),
+        edges: new Map([
+          ['x', new Set(['y', 'z'])],
+          ['y', new Set(['z', 'w'])],
+        ]),
+        output: new Map([
+          ['x', new Set(['y', 'z', 'w'])],
+          ['y', new Set(['z', 'w'])],
+          ['z', new Set()],
+          ['w', new Set()],
+        ]),
+      },
+      {
+        vertices: new Set(['x', 'y', 'z', 'w']),
+        edges: new Map([
+          ['x', new Set(['y'])],
+          ['y', new Set(['z'])],
+          ['z', new Set(['w'])],
+          ['w', new Set(['y'])],
+        ]),
+        output: new Map([
+          ['x', new Set(['y', 'z', 'w'])],
+          ['y', new Set(['z', 'w'])],
+          ['z', new Set(['y', 'w'])],
+          ['w', new Set(['z', 'y'])],
+        ]),
+      },
+    ];
+
+    for (const graph of graphs) {
+      expect(
+        _.isEqual(
+          manipulator.calculateDescendants(graph.vertices, graph.edges),
+          graph.output
+        )
+      ).toBeTrue();
+    }
+  });
+
+  it('calculates declaration types given declaration dependencies', () => {
+    const sampleDeclarationsSourceFile = project.createSourceFile(
+      'test_declarations.ts',
+      'let x; let y; let z; let w;'
+    );
 
     expect(
-      basicGraph.sorted.some(expectedOut =>
-        _.isEqual(
-          expectedOut,
-          manipulator.topoSort(basicGraph.vertices, basicGraph.edges)
-        )
+      sampleDeclarationsSourceFile.getVariableDeclaration('x')
+    ).toBeDefined();
+    expect(
+      sampleDeclarationsSourceFile.getVariableDeclaration('y')
+    ).toBeDefined();
+    expect(
+      sampleDeclarationsSourceFile.getVariableDeclaration('z')
+    ).toBeDefined();
+    expect(
+      sampleDeclarationsSourceFile.getVariableDeclaration('w')
+    ).toBeDefined();
+
+    const sampleDeclarations = {
+      x: sampleDeclarationsSourceFile.getVariableDeclaration('x')!,
+      y: sampleDeclarationsSourceFile.getVariableDeclaration('y')!,
+      z: sampleDeclarationsSourceFile.getVariableDeclaration('z')!,
+      w: sampleDeclarationsSourceFile.getVariableDeclaration('w')!,
+    };
+
+    const testCases = [
+      // Basic case: x: string -> y -> z
+      // Expected: x: string; y: string; z: string
+      {
+        calculatedDeclarationTypes: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+        ]),
+        sortedDeclarations: [
+          sampleDeclarations.x,
+          sampleDeclarations.y,
+          sampleDeclarations.z,
+        ],
+        directDeclarationDependencies: new Map([
+          [sampleDeclarations.x, new Set([sampleDeclarations.y])],
+          [sampleDeclarations.y, new Set([sampleDeclarations.z])],
+        ]),
+        output: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+          [sampleDeclarations.y, new Set(['string'])],
+          [sampleDeclarations.z, new Set(['string'])],
+        ]),
+      },
+
+      // New types case: x: string -> y: number -> z: boolean
+      // Expected: x: string; y: number | string; z: boolean | number | string
+      {
+        calculatedDeclarationTypes: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+          [sampleDeclarations.y, new Set(['number'])],
+          [sampleDeclarations.z, new Set(['boolean'])],
+        ]),
+        sortedDeclarations: [
+          sampleDeclarations.x,
+          sampleDeclarations.y,
+          sampleDeclarations.z,
+        ],
+        directDeclarationDependencies: new Map([
+          [sampleDeclarations.x, new Set([sampleDeclarations.y])],
+          [sampleDeclarations.y, new Set([sampleDeclarations.z])],
+        ]),
+        output: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+          [sampleDeclarations.y, new Set(['string', 'number'])],
+          [sampleDeclarations.z, new Set(['string', 'number', 'boolean'])],
+        ]),
+      },
+
+      // Any pollution case: x: string -> y: any -> z: boolean
+      // Expected: x: string; y: number | string; z: boolean | number | string
+      {
+        calculatedDeclarationTypes: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+          [sampleDeclarations.y, new Set(['any'])],
+          [sampleDeclarations.z, new Set(['boolean'])],
+        ]),
+        sortedDeclarations: [
+          sampleDeclarations.x,
+          sampleDeclarations.y,
+          sampleDeclarations.z,
+        ],
+        directDeclarationDependencies: new Map([
+          [sampleDeclarations.x, new Set([sampleDeclarations.y])],
+          [sampleDeclarations.y, new Set([sampleDeclarations.z])],
+        ]),
+        output: new Map([[sampleDeclarations.x, new Set(['string'])]]),
+      },
+
+      // Circular dependency case case: x: string -> y -> z -> w: number -> y
+      // Expected: x: string; y: number | string; z: number | string; w: number | string
+      {
+        calculatedDeclarationTypes: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+          [sampleDeclarations.y, new Set([])],
+          [sampleDeclarations.z, new Set([])],
+          [sampleDeclarations.z, new Set(['number'])],
+        ]),
+        sortedDeclarations: [
+          sampleDeclarations.x,
+          sampleDeclarations.y,
+          sampleDeclarations.z,
+          sampleDeclarations.w,
+        ],
+        directDeclarationDependencies: new Map([
+          [sampleDeclarations.x, new Set([sampleDeclarations.y])],
+          [sampleDeclarations.y, new Set([sampleDeclarations.z])],
+          [sampleDeclarations.z, new Set([sampleDeclarations.w])],
+          [sampleDeclarations.w, new Set([sampleDeclarations.y])],
+        ]),
+        output: new Map([
+          [sampleDeclarations.x, new Set(['string'])],
+          [sampleDeclarations.y, new Set(['string', 'number'])],
+          [sampleDeclarations.z, new Set(['string', 'number'])],
+          [sampleDeclarations.w, new Set(['string', 'number'])],
+        ]),
+      },
+    ];
+
+    for (const testCase of testCases) {
+      manipulator.calculateDeclarationTypes(
+        testCase.calculatedDeclarationTypes,
+        testCase.sortedDeclarations,
+        testCase.directDeclarationDependencies
+      );
+      expect(
+        _.isEqual(testCase.calculatedDeclarationTypes, testCase.output)
+      ).toBeTrue();
+    }
+
+    project.removeSourceFile(sampleDeclarationsSourceFile);
+  });
+
+  it('adds assignment dependencies', () => {
+    const sampleDeclarationsSourceFile = project.createSourceFile(
+      'test_declarations.ts',
+      'let x: string; let y = 0; y = x;'
+    );
+
+    expect(
+      sampleDeclarationsSourceFile.getVariableDeclaration('x')
+    ).toBeDefined();
+    expect(
+      sampleDeclarationsSourceFile.getVariableDeclaration('y')
+    ).toBeDefined();
+
+    const sampleDeclarations = {
+      x: sampleDeclarationsSourceFile.getVariableDeclaration('x')!,
+      y: sampleDeclarationsSourceFile.getVariableDeclaration('y')!,
+    };
+
+    const testCase = {
+      declaration: sampleDeclarations.y,
+      calculatedDeclarationTypes: new Map(),
+      directDeclarationDependencies: new Map(),
+      modifiedDeclarations: new Set([
+        sampleDeclarations.x,
+        sampleDeclarations.y,
+      ]),
+      outputCalculatedDeclarationTypes: new Map([
+        [sampleDeclarations.y, new Set(['number'])],
+      ]),
+      outputDirectDeclarationDependencies: new Map([
+        [sampleDeclarations.x, new Set([sampleDeclarations.y])],
+      ]),
+    };
+
+    manipulator.addAssignmentDeclarationDependencies(
+      testCase.declaration,
+      testCase.directDeclarationDependencies,
+      testCase.calculatedDeclarationTypes,
+      testCase.modifiedDeclarations
+    );
+    expect(
+      _.isEqual(
+        testCase.calculatedDeclarationTypes,
+        testCase.outputCalculatedDeclarationTypes
+      )
+    ).toBeTrue();
+    expect(
+      _.isEqual(
+        testCase.directDeclarationDependencies,
+        testCase.outputDirectDeclarationDependencies
       )
     ).toBeTrue();
 
-    const cycleGraph = {
-      vertices: new Set(['x', 'y', 'z', 'w']),
-      edges: new Map([
-        ['x', new Set(['y'])],
-        ['y', new Set(['z'])],
-        ['z', new Set(['w'])],
-        ['w', new Set(['y'])],
-      ]),
-      sorted: ['x', 'y', 'z', 'w'],
+    project.removeSourceFile(sampleDeclarationsSourceFile);
+  });
+
+  it('adds function call dependencies', () => {
+    const sampleDeclarationsSourceFile = project.createSourceFile(
+      'test_declarations.ts',
+      'let x = 0; foo(x); function foo(y) {}'
+    );
+
+    expect(
+      sampleDeclarationsSourceFile.getVariableDeclaration('x')
+    ).toBeDefined();
+    expect(
+      sampleDeclarationsSourceFile.getFunction('foo')?.getParameter('y')
+    ).toBeDefined();
+
+    const sampleDeclarations = {
+      x: sampleDeclarationsSourceFile.getVariableDeclaration('x')!,
+      y: sampleDeclarationsSourceFile.getFunction('foo')!.getParameter('y')!,
     };
+
+    const testCase = {
+      declaration: sampleDeclarations.y,
+      calculatedDeclarationTypes: new Map(),
+      directDeclarationDependencies: new Map(),
+      modifiedDeclarations: new Set([
+        sampleDeclarations.x,
+        sampleDeclarations.y,
+      ]),
+      outputDirectDeclarationDependencies: new Map([
+        [sampleDeclarations.x, new Set([sampleDeclarations.y])],
+      ]),
+    };
+
+    manipulator.addFunctionCallDeclarationDependencies(
+      testCase.declaration,
+      testCase.directDeclarationDependencies,
+      testCase.calculatedDeclarationTypes,
+      testCase.modifiedDeclarations
+    );
 
     expect(
       _.isEqual(
-        cycleGraph.sorted,
-        manipulator.topoSort(cycleGraph.vertices, cycleGraph.edges)
+        testCase.directDeclarationDependencies,
+        testCase.outputDirectDeclarationDependencies
       )
     ).toBeTrue();
+
+    project.removeSourceFile(sampleDeclarationsSourceFile);
   });
 });

--- a/test/no_implicit_any_test.ts
+++ b/test/no_implicit_any_test.ts
@@ -24,7 +24,7 @@ import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {Emitter} from '@/src/emitters/emitter';
 import {NoImplicitAnyManipulator} from '@/src/manipulators/no_implicit_any_manipulator';
 
-describe('NoImplicitAnyManipulator ', () => {
+describe('NoImplicitAnyManipulator', () => {
   let project: Project;
   let errorDetector: ErrorDetector;
   let emitter: Emitter;
@@ -50,43 +50,54 @@ describe('NoImplicitAnyManipulator ', () => {
 
   const testFiles = [
     {
-      description: 'fixes when function is missing return statement',
-      inputFilePath: './test/test_files/no_implicit_returns/no_return.ts',
+      description: 'fixes basic cases of assignment and function calls',
+      inputFilePath:
+        './test/test_files/no_implicit_any/basic_assignment_and_functions.ts',
       actualOutputFilePath:
-        './test/test_files/no_implicit_returns/ts_upgrade/no_return.ts',
+        './test/test_files/no_implicit_any/ts_upgrade/basic_assignment_and_functions.ts',
       expectedOutputFilePath:
-        './test/test_files/golden/no_implicit_returns/no_return.ts',
+        './test/test_files/golden/no_implicit_any/basic_assignment_and_functions.ts',
+    },
+    {
+      description:
+        'fixes declarations that require resolving in specific order',
+      inputFilePath:
+        './test/test_files/no_implicit_any/topologically_dependent.ts',
+      actualOutputFilePath:
+        './test/test_files/no_implicit_any/ts_upgrade/topologically_dependent.ts',
+      expectedOutputFilePath:
+        './test/test_files/golden/no_implicit_any/topologically_dependent.ts',
     },
   ];
 
-  // for (let test of testFiles) {
-  //   it(test.description, () => {
-  //     const input = project.addSourceFileAtPath(test.inputFilePath);
-  //     project.resolveSourceFileDependencies();
+  for (let test of testFiles) {
+    it(test.description, () => {
+      const input = project.addSourceFileAtPath(test.inputFilePath);
+      project.resolveSourceFileDependencies();
 
-  //     new Runner(
-  //       /* args*/ undefined,
-  //       project,
-  //       /* parser */ undefined,
-  //       errorDetector,
-  //       [manipulator],
-  //       emitter
-  //     ).run();
+      new Runner(
+        /* args*/ undefined,
+        project,
+        /* parser */ undefined,
+        errorDetector,
+        [manipulator],
+        emitter
+      ).run();
 
-  //     const expectedOutput = project.addSourceFileAtPath(
-  //       test.expectedOutputFilePath
-  //     );
-  //     const actualOutput = project.addSourceFileAtPath(
-  //       test.actualOutputFilePath
-  //     );
+      const expectedOutput = project.addSourceFileAtPath(
+        test.expectedOutputFilePath
+      );
+      const actualOutput = project.addSourceFileAtPath(
+        test.actualOutputFilePath
+      );
 
-  //     expect(actualOutput).toHaveSameASTAs(expectedOutput);
+      expect(actualOutput).toHaveSameASTAs(expectedOutput);
 
-  //     project.removeSourceFile(input);
-  //     project.removeSourceFile(actualOutput);
-  //     project.removeSourceFile(expectedOutput);
-  //   });
-  // }
+      project.removeSourceFile(input);
+      project.removeSourceFile(actualOutput);
+      project.removeSourceFile(expectedOutput);
+    });
+  }
 
   it('topologically sorts graph', () => {
     const basicGraph = {
@@ -101,9 +112,6 @@ describe('NoImplicitAnyManipulator ', () => {
       ],
     };
 
-    expect(
-      manipulator.topoSort(basicGraph.vertices, basicGraph.edges)
-    ).toBeDefined();
     expect(
       basicGraph.sorted.some(expectedOut =>
         _.isEqual(
@@ -121,10 +129,14 @@ describe('NoImplicitAnyManipulator ', () => {
         ['z', new Set(['w'])],
         ['w', new Set(['y'])],
       ]),
+      sorted: ['x'],
     };
 
     expect(
-      manipulator.topoSort(cycleGraph.vertices, cycleGraph.edges)
-    ).toBeUndefined();
+      _.isEqual(
+        cycleGraph.sorted,
+        manipulator.topoSort(cycleGraph.vertices, cycleGraph.edges)
+      )
+    ).toBeTrue();
   });
 });

--- a/test/no_implicit_any_test.ts
+++ b/test/no_implicit_any_test.ts
@@ -1,0 +1,97 @@
+/*
+    Copyright 2020 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Project} from 'ts-morph';
+import {Runner} from '@/src/runner';
+import {OutOfPlaceEmitter} from '@/src/emitters/out_of_place_emitter';
+import {SourceFileComparer} from '@/testing/source_file_matcher';
+import {ProdErrorDetector} from '@/src/error_detectors/prod_error_detector';
+import {ErrorDetector} from '@/src/error_detectors/error_detector';
+import {Emitter} from '@/src/emitters/emitter';
+import {NoImplicitAnyManipulator} from '@/src/manipulators/no_implicit_any_manipulator';
+
+describe('NoImplicitAnyManipulator', () => {
+  let project: Project;
+  let errorDetector: ErrorDetector;
+  let emitter: Emitter;
+  let manipulator: NoImplicitAnyManipulator;
+
+  beforeAll(() => {
+    jasmine.addMatchers(SourceFileComparer);
+
+    const relativeOutputPath = './ts_upgrade';
+    const inputConfigPath = './test/test_files/tsconfig.json';
+
+    project = new Project({
+      tsConfigFilePath: inputConfigPath,
+      addFilesFromTsConfig: false,
+      compilerOptions: {
+        noImplicitReturns: true,
+      },
+    });
+    errorDetector = new ProdErrorDetector();
+    emitter = new OutOfPlaceEmitter(relativeOutputPath);
+    manipulator = new NoImplicitAnyManipulator(errorDetector);
+  });
+
+  const testFiles = [
+    {
+      description: 'fixes when function is missing return statement',
+      inputFilePath: './test/test_files/no_implicit_returns/no_return.ts',
+      actualOutputFilePath:
+        './test/test_files/no_implicit_returns/ts_upgrade/no_return.ts',
+      expectedOutputFilePath:
+        './test/test_files/golden/no_implicit_returns/no_return.ts',
+    },
+    {
+      description: 'fixes when return statement is empty',
+      inputFilePath: './test/test_files/no_implicit_returns/empty_return.ts',
+      actualOutputFilePath:
+        './test/test_files/no_implicit_returns/ts_upgrade/empty_return.ts',
+      expectedOutputFilePath:
+        './test/test_files/golden/no_implicit_returns/empty_return.ts',
+    },
+  ];
+
+  for (let test of testFiles) {
+    it(test.description, () => {
+      const input = project.addSourceFileAtPath(test.inputFilePath);
+      project.resolveSourceFileDependencies();
+
+      new Runner(
+        /* args*/ undefined,
+        project,
+        /* parser */ undefined,
+        errorDetector,
+        [manipulator],
+        emitter
+      ).run();
+
+      const expectedOutput = project.addSourceFileAtPath(
+        test.expectedOutputFilePath
+      );
+      const actualOutput = project.addSourceFileAtPath(
+        test.actualOutputFilePath
+      );
+
+      expect(actualOutput).toHaveSameASTAs(expectedOutput);
+
+      project.removeSourceFile(input);
+      project.removeSourceFile(actualOutput);
+      project.removeSourceFile(expectedOutput);
+    });
+  }
+});

--- a/test/no_implicit_any_test.ts
+++ b/test/no_implicit_any_test.ts
@@ -129,7 +129,7 @@ describe('NoImplicitAnyManipulator', () => {
         ['z', new Set(['w'])],
         ['w', new Set(['y'])],
       ]),
-      sorted: ['x'],
+      sorted: ['x', 'y', 'z', 'w'],
     };
 
     expect(

--- a/test/test_files/golden/no_implicit_any/basic_assignment_and_functions.ts
+++ b/test/test_files/golden/no_implicit_any/basic_assignment_and_functions.ts
@@ -45,3 +45,11 @@ function passString(val: string) {
 function passNum(val: string) {
   calledByPassNumAndPassString(val);
 }
+
+//Test: Prevents "any" pollution.
+function passAnyValues(foo: any, bar: any[]) {
+  calledByPassAnyValues(foo);
+  calledByPassAnyValues(bar);
+}
+
+function calledByPassAnyValues(foo) {}

--- a/test/test_files/golden/no_implicit_any/basic_assignment_and_functions.ts
+++ b/test/test_files/golden/no_implicit_any/basic_assignment_and_functions.ts
@@ -1,0 +1,47 @@
+// Test: Assigns type based on assignment to literal
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function assignsToStringLiteral(val: string) {
+  val = '';
+}
+
+// Test: Assigns type based on assignment to expression
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function assignsToStringExpression(val: string) {
+  val = returnsString();
+}
+
+function returnsString(): string {
+  return '';
+}
+
+// Test: Assigns type based on multiple assignments
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function assignsToNumAndString(val: number | string) {
+  val = '';
+  val = 0;
+}
+
+// Test: Assigns type based on function call and assignment
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function calledByNumAssignToString(val: number | string) {
+  val = '';
+}
+
+calledByNumAssignToString(5);
+
+// Test: Assigns type based on function calls
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function calledByPassString(val: string) {}
+
+// Test: Assigns type based on multiple function calls
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function calledByPassNumAndPassString(val: string) {}
+
+function passString(val: string) {
+  calledByPassString(val);
+  calledByPassNumAndPassString(val);
+}
+
+function passNum(val: string) {
+  calledByPassNumAndPassString(val);
+}

--- a/test/test_files/golden/no_implicit_any/topologically_dependent.ts
+++ b/test/test_files/golden/no_implicit_any/topologically_dependent.ts
@@ -14,4 +14,4 @@ function foo(z: number | string) {
 }
 
 // typescript-flag-upgrade automated fix: --noImplicitAny
-function bar(w: string) {}
+function bar(w: number | string) {}

--- a/test/test_files/golden/no_implicit_any/topologically_dependent.ts
+++ b/test/test_files/golden/no_implicit_any/topologically_dependent.ts
@@ -1,0 +1,17 @@
+let x = '';
+// typescript-flag-upgrade automated fix: --noImplicitAny
+let y: number | string;
+
+y = 0;
+y = x;
+
+foo(x);
+bar(y);
+
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function foo(z: number | string) {
+  z = y;
+}
+
+// typescript-flag-upgrade automated fix: --noImplicitAny
+function bar(w: string) {}

--- a/test/test_files/no_implicit_any/basic_assignment_and_functions.ts
+++ b/test/test_files/no_implicit_any/basic_assignment_and_functions.ts
@@ -45,3 +45,11 @@ function passString(val: string) {
 function passNum(val: string) {
   calledByPassNumAndPassString(val);
 }
+
+//Test: Prevents "any" pollution.
+function passAnyValues(foo: any, bar: any[]) {
+  calledByPassAnyValues(foo);
+  calledByPassAnyValues(bar);
+}
+
+function calledByPassAnyValues(foo) {}

--- a/test/test_files/no_implicit_any/basic_assignment_and_functions.ts
+++ b/test/test_files/no_implicit_any/basic_assignment_and_functions.ts
@@ -1,0 +1,47 @@
+// Test: Assigns type based on assignment to literal
+// Fix: callsTakeString(val: string) {
+function assignsToStringLiteral(val) {
+  val = '';
+}
+
+// Test: Assigns type based on assignment to expression
+// Fix: assignsToStringExpression(val: string) {
+function assignsToStringExpression(val) {
+  val = returnsString();
+}
+
+function returnsString(): string {
+  return '';
+}
+
+// Test: Assigns type based on multiple assignments
+// Fix: assignsToNumAndString(val: number | string) {
+function assignsToNumAndString(val) {
+  val = '';
+  val = 0;
+}
+
+// Test: Assigns type based on function call and assignment
+// Fix: calledByNumAssignToString(val: number | string) {
+function calledByNumAssignToString(val) {
+  val = '';
+}
+
+calledByNumAssignToString(5);
+
+// Test: Assigns type based on function calls
+// Fix: calledByPassString(val: string) {
+function calledByPassString(val) {}
+
+// Test: Assigns type based on multiple function calls
+// Fix: calledByPassNumAndPassString(val: number | string) {
+function calledByPassNumAndPassString(val) {}
+
+function passString(val: string) {
+  calledByPassString(val);
+  calledByPassNumAndPassString(val);
+}
+
+function passNum(val: string) {
+  calledByPassNumAndPassString(val);
+}

--- a/test/test_files/no_implicit_any/topologically_dependent.ts
+++ b/test/test_files/no_implicit_any/topologically_dependent.ts
@@ -1,0 +1,17 @@
+let x = '';
+// Fix: let y: number | string;
+let y;
+
+y = 0;
+y = x;
+
+foo(x);
+bar(y);
+
+// Fix: function foo(z: number | string) {
+function foo(z) {
+  z = y;
+}
+
+// Fix: function bar(w: string) {}
+function bar(w) {}

--- a/test/test_files/no_implicit_any/topologically_dependent.ts
+++ b/test/test_files/no_implicit_any/topologically_dependent.ts
@@ -13,5 +13,5 @@ function foo(z) {
   z = y;
 }
 
-// Fix: function bar(w: string) {}
+// Fix: function bar(w: number | string) {}
 function bar(w) {}


### PR DESCRIPTION
## Issue
Fixes #27 

## Description
Implements `NoImplicitAnyManipulator` to fix for variable and parameter cases of `--noImplicitAny`. Namely, implements the basic topological sorting fix as described in my deep dive presentation. 
1. First constructs a set of declarations that are implicitly any.
2. Constructs a dependency graph based on the values and expressions each variable is assigned to. If the variable is a parameter, also looks for all function calls and extracts the function arguments' types and expressions.
3. Topologically sorts the graph.
4. In topological order, assigns the types to each declaration. If a declaration has type any, console logs and skips the declaration, as well all declarations that rely on it.

I moved a few functions from `StrictNullChecksManipulator` to `Manipulator` as their functionality was shared between `StrictNullChecksManipulator` and `NoImplicitAnyManipulator`.

Note: This implementation does _not_ fix for more complex cases involving empty arrays or objects, as those cases must be fixed with hardcoded implementations, which may be dangerous if not every cases is taken into account.

## Tests
Unit Tests:
- Topologically sorts graph
- Constructs descendants map
- Calculates declaration types given declaration dependencies
- Adds assignment dependencies
- Adds function call dependencies

Functional Tests:
- Assigns types based on assignments to literals / expressions
- Assigns types based on function calls
- Assigns types based on dependencies between declarations (topologically sorting)
- Prevents `any` pollution