### PR TITLE
Rotate manipulators to ensure every fix is run at least once

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -16,7 +16,7 @@
 
 import path from 'path';
 import _ from 'lodash';
-import {Project, ts, LeftHandSideExpression} from 'ts-morph';
+import {Project, ts} from 'ts-morph';
 import {ArgumentOptions, DEFAULT_ARGS} from './types';
 import {Emitter} from './emitters/emitter';
 import {NoImplicitReturnsManipulator} from './manipulators/no_implicit_returns_manipulator';
@@ -69,9 +69,9 @@ export class Runner {
     this.errorDetector = errorDetector || new ProdErrorDetector();
     this.manipulators = manipulators || [
       new NoImplicitReturnsManipulator(this.errorDetector),
-      new NoImplicitAnyManipulator(this.errorDetector),
       new StrictPropertyInitializationManipulator(this.errorDetector),
       new StrictNullChecksManipulator(this.errorDetector),
+      new NoImplicitAnyManipulator(this.errorDetector),
     ];
     this.emitter = emitter || new InPlaceEmitter();
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -89,11 +89,16 @@ export class Runner {
 
     let errors = this.parser.parse(this.project);
     let prevErrors = errors;
-    let errorsExist;
+    let errorsExist: boolean;
+    let rotatedManipulators: Manipulator[];
 
     do {
       errorsExist = false;
+      rotatedManipulators = [...this.manipulators];
+
       for (const manipulator of this.manipulators) {
+        rotatedManipulators.push(rotatedManipulators.shift()!);
+
         if (manipulator.hasErrors(errors)) {
           manipulator.fixErrors(errors);
           errorsExist = true;
@@ -102,6 +107,8 @@ export class Runner {
           break;
         }
       }
+
+      this.manipulators = rotatedManipulators;
     } while (errorsExist && !_.isEqual(errors, prevErrors));
     // TODO: Log if previous errors are same as current errors.
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -87,6 +87,7 @@ export class Runner {
       })
     );
 
+    // Parse errors, save copy of errors.
     let errors = this.parser.parse(this.project);
     let prevErrors = errors;
     let errorsExist: boolean;
@@ -96,9 +97,12 @@ export class Runner {
       errorsExist = false;
       rotatedManipulators = [...this.manipulators];
 
+      // For each manipulator, check if there are errors that it can fix.
       for (const manipulator of this.manipulators) {
+        // Rotate the manipulator list to the left
         rotatedManipulators.push(rotatedManipulators.shift()!);
 
+        // If a manipulator detects errors that it can fix, fix them and reparse errors.
         if (manipulator.hasErrors(errors)) {
           manipulator.fixErrors(errors);
           errorsExist = true;
@@ -108,9 +112,12 @@ export class Runner {
         }
       }
 
+      // Rotate manipulators so that in next iteration, the next manipulator is run first.
       this.manipulators = rotatedManipulators;
+
+      // If previous iterations' errors are same as current errors, no more errors can be fixed so exit loop.
+      // TODO: Log if previous errors are same as current errors.
     } while (errorsExist && !_.isEqual(errors, prevErrors));
-    // TODO: Log if previous errors are same as current errors.
 
     this.emitter.emit(this.project);
   }


### PR DESCRIPTION
Fixes #33. Two main fixes:

1. While fixing for noImplicitAny, I noticed that there was a bug in the judgement while loop in my `Runner` class. Namely, when one of the earlier manipulators in the list (say, `StrictNullChecksManipulator`) fixes for some errors but is not able to fix for all errors, those same errors appear in the next iteration of the judgement loop. Because we are checking between each iteration if the errors are the same, that means that the runner is prematurely exiting this loop before going through all the manipulators. The way I fixed this was to ensure that every manipulator was "checked/run" at least once, by rotating the list of manipulators. That way, once manipulator N implements its fixes, in the next iteration of the judgement loop, the runner first starts with checking manipulator N+1 and so on.

2. In addition, I noticed that in general, because `StrictNullChecksManipulator` is responsible for adding `null` and `undefined` types to variable and parameter declarations, it would be more helpful to first address `-strictNullChecks` before doing the type inference in `NoImplicitAnyManipulator`. As a a result, I reordered the manipulator list to reflect this. Doing this should not change the implementation result, rather just reducing the number of iterations of fixes that's required to achieve the same result.