### PR TITLE
Fix bug with generating unnecessary ts_upgrade files

### DIFF
--- a/test/no_implicit_returns_test.ts
+++ b/test/no_implicit_returns_test.ts
@@ -29,7 +29,7 @@ describe('NoImplicitReturnsManipulator', () => {
   let emitter: Emitter;
   let manipulator: NoImplicitReturnsManipulator;
 
-  beforeAll(() => {
+  beforeEach(() => {
     jasmine.addMatchers(SourceFileComparer);
 
     const relativeOutputPath = './ts_upgrade';

--- a/test/strict_null_checks_test.ts
+++ b/test/strict_null_checks_test.ts
@@ -29,7 +29,7 @@ describe('StrictNullChecksManipulator', () => {
   let emitter: Emitter;
   let manipulator: StrictNullChecksManipulator;
 
-  beforeAll(() => {
+  beforeEach(() => {
     jasmine.addMatchers(SourceFileComparer);
 
     const relativeOutputPath = './ts_upgrade';

--- a/test/strict_property_initialization_test.ts
+++ b/test/strict_property_initialization_test.ts
@@ -31,7 +31,7 @@ describe('StrictPropertyInitializationManipulator', () => {
   let emitter: Emitter;
   let manipulators: Manipulator[];
 
-  beforeAll(() => {
+  beforeEach(() => {
     jasmine.addMatchers(SourceFileComparer);
 
     const relativeOutputPath = './ts_upgrade';


### PR DESCRIPTION
When writing unit tests, I noticed that there was a bug where I was emitting/generating unnecessary `ts_upgrade` directories. This was because I wasn't creating separate projects for each of my test cases, so my tests were emitting the same projects again and again for each test case, so I changed `beforeAll` to `beforeEach` to fix and prevent this from happening.