### PR TITLE
Add error message when encountered implicitly any object type or return type

### DIFF
--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -151,8 +151,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
     nodeDiagnostics.forEach(({node: node, diagnostic: diagnostic}) => {
       switch (diagnostic.getCode()) {
         case ErrorCodes.ReturnTypeImplicitlyAny: {
-          // TODO: Move console log functionality to a logger class.
-          console.log(
+          this.logger.log(
             chalk.cyan(`${node.getSourceFile().getFilePath()}`) +
               ':' +
               chalk.yellow(`${node.getStartLineNumber()}`) +
@@ -165,8 +164,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
           break;
         }
         case ErrorCodes.ObjectPropertyImplicitlyAny: {
-          // TODO: Move console log functionality to a logger class.
-          console.log(
+          this.logger.log(
             chalk.cyan(`${node.getSourceFile().getFilePath()}`) +
               ':' +
               chalk.yellow(`${node.getStartLineNumber()}`) +

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,8 @@ export enum ErrorCodes {
   PropertyNoInitializer = 2564,
   VariableImplicitlyAny = 7005,
   ParameterImplicitlyAny = 7006,
+  ReturnTypeImplicitlyAny = 7010,
+  ObjectPropertyImplicitlyAny = 7053,
 }
 
 export type DeclarationType = Map<


### PR DESCRIPTION
## Issue
Fixes #41 

## Description
Previously, our `NoImplicitAnyManipulator` was merely ignoring cases involving object types and functions with return types that are implicitly any. This PR fixes this by logging to the user whenever one of these cases is encountered, so that the user is aware of the limitations of this tool.