### PR TITLE
Implement logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,15 +31,6 @@ const args = yargs
       normalize: true,
       type: 'string',
     },
-    m: {
-      alias: 'mode',
-      demandOption: true,
-      default: DEFAULT_ARGS.m,
-      description:
-        "Option between only leaving comments ('comment') or both comments and mutative fixes ('all')",
-      type: 'string',
-      choices: ['all', 'comment'],
-    },
     i: {
       alias: 'input_directory',
       demandOption: false,
@@ -47,17 +38,8 @@ const args = yargs
       normalize: true,
       type: 'string',
     },
-    l: {
-      alias: 'log_location',
-      demandOption: false,
-      description: 'Specify file for logging',
-      normalize: true,
-      type: 'string',
-    },
   })
-  .usage(
-    'typescript-flag-upgrade -p <path-to-config> [-m <all|comment>] [-i <path-to-input-dir>] [-l <path-to-log>]'
-  )
+  .usage('typescript-flag-upgrade -p <path-to-config> [-i <path-to-input-dir>]')
   .epilogue('Copyright 2020 Google LLC').argv;
 
 new Runner(args).run();

--- a/src/loggers/console_logger.ts
+++ b/src/loggers/console_logger.ts
@@ -1,0 +1,29 @@
+/*
+    Copyright 2020 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Logger} from './logger';
+
+/** Logger that logs to console. */
+export class ConsoleLogger extends Logger {
+  /**
+   * Logs message to console.
+   * @param {any} message - Message to be logged.
+   */
+  // eslint-disable-next-line
+  log(message: any): void {
+    console.log(message);
+  }
+}

--- a/src/loggers/logger.ts
+++ b/src/loggers/logger.ts
@@ -1,0 +1,25 @@
+/*
+    Copyright 2020 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/** Base class for logging tool progress and errors. */
+export abstract class Logger {
+  /**
+   * Logs message, implemented by subclasses.
+   * @param {any} message - Message to be logged.
+   */
+  // eslint-disable-next-line
+  abstract log(message: any): void;
+}

--- a/src/loggers/stub_logger.ts
+++ b/src/loggers/stub_logger.ts
@@ -1,0 +1,27 @@
+/*
+    Copyright 2020 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import {Logger} from './logger';
+
+/** Stub logger that does not log, for testing. */
+export class StubLogger extends Logger {
+  /**
+   * Stub log method.
+   * @param {any} message - Message to be logged.
+   */
+  // eslint-disable-next-line
+  log(message: any): void {}
+}

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -16,10 +16,12 @@
 
 import {Diagnostic, ts, Node, Type, Statement, TypeFormatFlags} from 'ts-morph';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
+import {Logger} from '@/src/loggers/logger';
 
 /** Base class for manipulating AST to fix for flags. */
 export abstract class Manipulator {
   errorDetector: ErrorDetector;
+  logger: Logger;
   errorCodesToFix: Set<number>;
 
   /**
@@ -27,8 +29,13 @@ export abstract class Manipulator {
    * @param {ErrorDetector} errorDetector - Util class for filtering diagnostics.
    * @param {Set<number>} errorCodesToFix - Codes of compiler flag errors.
    */
-  constructor(errorDetector: ErrorDetector, errorCodesToFix: Set<number>) {
+  constructor(
+    errorDetector: ErrorDetector,
+    logger: Logger,
+    errorCodesToFix: Set<number>
+  ) {
     this.errorDetector = errorDetector;
+    this.logger = logger;
     this.errorCodesToFix = errorCodesToFix;
   }
 

--- a/src/manipulators/no_implicit_any_manipulator.ts
+++ b/src/manipulators/no_implicit_any_manipulator.ts
@@ -26,6 +26,7 @@ import {
 import chalk from 'chalk';
 import {ErrorDetector} from 'src/error_detectors/error_detector';
 import {ErrorCodes, NO_IMPLICIT_ANY_COMMENT, NodeDiagnostic} from '@/src/types';
+import {Logger} from '@/src/loggers/logger';
 
 type AcceptedDeclaration = VariableDeclaration | ParameterDeclaration;
 
@@ -36,9 +37,10 @@ type AcceptedDeclaration = VariableDeclaration | ParameterDeclaration;
 export class NoImplicitAnyManipulator extends Manipulator {
   private nodeKinds: Set<SyntaxKind>;
 
-  constructor(errorDetector: ErrorDetector) {
+  constructor(errorDetector: ErrorDetector, logger: Logger) {
     super(
       errorDetector,
+      logger,
       new Set<number>([
         ErrorCodes.VariableImplicitlyAny,
         ErrorCodes.ParameterImplicitlyAny,
@@ -371,7 +373,7 @@ export class NoImplicitAnyManipulator extends Manipulator {
         )
       ) {
         // TODO: Move console log functionality to a logger class.
-        console.log(
+        this.logger.log(
           chalk.cyan(`${declaration.getSourceFile().getFilePath()}`) +
             ':' +
             chalk.yellow(`${declaration.getStartLineNumber()}`) +

--- a/src/manipulators/no_implicit_returns_manipulator.ts
+++ b/src/manipulators/no_implicit_returns_manipulator.ts
@@ -18,6 +18,7 @@ import {Diagnostic, ts, Node, SyntaxKind, StatementedNode} from 'ts-morph';
 import {Manipulator} from './manipulator';
 import {ErrorCodes, NO_IMPLICIT_RETURNS_COMMENT} from '@/src/types';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
+import {Logger} from '@/src/loggers/logger';
 
 /**
  * Manipulator that fixes for the noImplicitReturns compiler flag.
@@ -26,9 +27,10 @@ import {ErrorDetector} from '@/src/error_detectors/error_detector';
 export class NoImplicitReturnsManipulator extends Manipulator {
   private nodeKinds: Set<SyntaxKind>;
 
-  constructor(errorDetector: ErrorDetector) {
+  constructor(errorDetector: ErrorDetector, logger: Logger) {
     super(
       errorDetector,
+      logger,
       new Set<number>([ErrorCodes.CodePathNoReturn])
     );
     this.nodeKinds = new Set<SyntaxKind>([

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -36,6 +36,7 @@ import {
   DeclarationType,
   STRICT_NULL_CHECKS_COMMENT,
 } from '@/src/types';
+import {Logger} from '@/src/loggers/logger';
 
 /**
  * Manipulator that fixes for the strictNullChecks compiler flag.
@@ -44,9 +45,10 @@ import {
 export class StrictNullChecksManipulator extends Manipulator {
   private nodeKinds: Set<SyntaxKind>;
 
-  constructor(errorDetector: ErrorDetector) {
+  constructor(errorDetector: ErrorDetector, logger: Logger) {
     super(
       errorDetector,
+      logger,
       new Set<number>([
         ErrorCodes.ObjectPossiblyNull,
         ErrorCodes.ObjectPossiblyUndefined,

--- a/src/manipulators/strict_property_initialization_manipulator.ts
+++ b/src/manipulators/strict_property_initialization_manipulator.ts
@@ -18,6 +18,7 @@ import {Manipulator} from './manipulator';
 import {Diagnostic, ts, SyntaxKind, Node, Identifier} from 'ts-morph';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {ErrorCodes, STRICT_PROPERTY_INITIALIZATION_COMMENT} from '@/src/types';
+import {Logger} from '@/src/loggers/logger';
 
 /**
  * Manipulator that fixes for the strictPropertyInitialization compiler flag.
@@ -26,9 +27,10 @@ import {ErrorCodes, STRICT_PROPERTY_INITIALIZATION_COMMENT} from '@/src/types';
 export class StrictPropertyInitializationManipulator extends Manipulator {
   private nodeKinds: Set<SyntaxKind>;
 
-  constructor(errorDetector: ErrorDetector) {
+  constructor(errorDetector: ErrorDetector, logger: Logger) {
     super(
       errorDetector,
+      logger,
       new Set<number>([ErrorCodes.PropertyNoInitializer])
     );
     this.nodeKinds = new Set<SyntaxKind>([SyntaxKind.Identifier]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,15 +28,8 @@ export type ArgumentOptions = {
   [x: string]: unknown;
   /** Relative path to TypeScript config file */
   p: string;
-  /**
-   * Option between only leaving comments ('comment') or both comments and
-   * mutative fixes ('all')
-   */
-  m: string;
   /** Override config and specify input directory */
   i?: string;
-  /** Specify file for logging */
-  l?: string;
   _: string[];
   $0: string;
 };
@@ -44,11 +37,6 @@ export type ArgumentOptions = {
 export const DEFAULT_ARGS = {
   /** Relative path to TypeScript config file */
   p: 'tsconfig.json',
-  /**
-   * Option between only leaving comments ('comment') or both comments and
-   * mutative fixes ('all')
-   */
-  m: 'all',
   _: [],
   $0: '',
 };

--- a/test/no_implicit_any_test.ts
+++ b/test/no_implicit_any_test.ts
@@ -23,11 +23,14 @@ import {ProdErrorDetector} from '@/src/error_detectors/prod_error_detector';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {Emitter} from '@/src/emitters/emitter';
 import {NoImplicitAnyManipulator} from '@/src/manipulators/no_implicit_any_manipulator';
+import {Logger} from '@/src/loggers/logger';
+import {StubLogger} from '@/src/loggers/stub_logger';
 
 describe('NoImplicitAnyManipulator', () => {
   let project: Project;
   let errorDetector: ErrorDetector;
   let emitter: Emitter;
+  let logger: Logger;
   let manipulator: NoImplicitAnyManipulator;
 
   beforeEach(() => {
@@ -45,7 +48,8 @@ describe('NoImplicitAnyManipulator', () => {
     });
     errorDetector = new ProdErrorDetector();
     emitter = new OutOfPlaceEmitter(relativeOutputPath);
-    manipulator = new NoImplicitAnyManipulator(errorDetector);
+    logger = new StubLogger();
+    manipulator = new NoImplicitAnyManipulator(errorDetector, logger);
   });
 
   const testFiles = [
@@ -81,7 +85,8 @@ describe('NoImplicitAnyManipulator', () => {
         /* parser */ undefined,
         errorDetector,
         [manipulator],
-        emitter
+        emitter,
+        logger
       ).run();
 
       const expectedOutput = project.addSourceFileAtPath(

--- a/test/no_implicit_returns_test.ts
+++ b/test/no_implicit_returns_test.ts
@@ -22,11 +22,14 @@ import {ProdErrorDetector} from '@/src/error_detectors/prod_error_detector';
 import {NoImplicitReturnsManipulator} from '@/src/manipulators/no_implicit_returns_manipulator';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {Emitter} from '@/src/emitters/emitter';
+import {Logger} from '@/src/loggers/logger';
+import {StubLogger} from '@/src/loggers/stub_logger';
 
 describe('NoImplicitReturnsManipulator', () => {
   let project: Project;
   let errorDetector: ErrorDetector;
   let emitter: Emitter;
+  let logger: Logger;
   let manipulator: NoImplicitReturnsManipulator;
 
   beforeEach(() => {
@@ -44,7 +47,8 @@ describe('NoImplicitReturnsManipulator', () => {
     });
     errorDetector = new ProdErrorDetector();
     emitter = new OutOfPlaceEmitter(relativeOutputPath);
-    manipulator = new NoImplicitReturnsManipulator(errorDetector);
+    logger = new StubLogger();
+    manipulator = new NoImplicitReturnsManipulator(errorDetector, logger);
   });
 
   const testFiles = [
@@ -77,7 +81,8 @@ describe('NoImplicitReturnsManipulator', () => {
         /* parser */ undefined,
         errorDetector,
         [manipulator],
-        emitter
+        emitter,
+        logger
       ).run();
 
       const expectedOutput = project.addSourceFileAtPath(

--- a/test/strict_null_checks_test.ts
+++ b/test/strict_null_checks_test.ts
@@ -22,11 +22,14 @@ import {ProdErrorDetector} from '@/src/error_detectors/prod_error_detector';
 import {StrictNullChecksManipulator} from '@/src/manipulators/strict_null_checks_manipulator';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {Emitter} from '@/src/emitters/emitter';
+import {Logger} from '@/src/loggers/logger';
+import {StubLogger} from '@/src/loggers/stub_logger';
 
 describe('StrictNullChecksManipulator', () => {
   let project: Project;
   let errorDetector: ErrorDetector;
   let emitter: Emitter;
+  let logger: Logger;
   let manipulator: StrictNullChecksManipulator;
 
   beforeEach(() => {
@@ -44,7 +47,8 @@ describe('StrictNullChecksManipulator', () => {
     });
     errorDetector = new ProdErrorDetector();
     emitter = new OutOfPlaceEmitter(relativeOutputPath);
-    manipulator = new StrictNullChecksManipulator(errorDetector);
+    logger = new StubLogger();
+    manipulator = new StrictNullChecksManipulator(errorDetector, logger);
   });
 
   const testFiles = [
@@ -88,7 +92,8 @@ describe('StrictNullChecksManipulator', () => {
         /* parser */ undefined,
         errorDetector,
         [manipulator],
-        emitter
+        emitter,
+        logger
       ).run();
 
       const expectedOutput = project.addSourceFileAtPath(

--- a/test/strict_property_initialization_test.ts
+++ b/test/strict_property_initialization_test.ts
@@ -24,11 +24,14 @@ import {StrictNullChecksManipulator} from '@/src/manipulators/strict_null_checks
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {Emitter} from '@/src/emitters/emitter';
 import {Manipulator} from '@/src/manipulators/manipulator';
+import {Logger} from '@/src/loggers/logger';
+import {StubLogger} from '@/src/loggers/stub_logger';
 
 describe('StrictPropertyInitializationManipulator', () => {
   let project: Project;
   let errorDetector: ErrorDetector;
   let emitter: Emitter;
+  let logger: Logger;
   let manipulators: Manipulator[];
 
   beforeEach(() => {
@@ -47,9 +50,10 @@ describe('StrictPropertyInitializationManipulator', () => {
     });
     errorDetector = new ProdErrorDetector();
     emitter = new OutOfPlaceEmitter(relativeOutputPath);
+    logger = new StubLogger();
     manipulators = [
-      new StrictPropertyInitializationManipulator(errorDetector),
-      new StrictNullChecksManipulator(errorDetector),
+      new StrictPropertyInitializationManipulator(errorDetector, logger),
+      new StrictNullChecksManipulator(errorDetector, logger),
     ];
   });
 
@@ -76,7 +80,8 @@ describe('StrictPropertyInitializationManipulator', () => {
         /* parser */ undefined,
         errorDetector,
         manipulators,
-        emitter
+        emitter,
+        logger
       ).run();
 
       const expectedOutput = project.addSourceFileAtPath(


### PR DESCRIPTION
## Issue
Fixes #8 

## Description
Previously, whenever we wanted to log an error message or the filepaths that the tool was reading in, we would `console.log`, which is in general bad practice. As such, this PR abstracts away logging into its own class. We also use dependency injection and use a `StubLogger` in testing so that tests do not trigger logs to console.

Also deletes unnecessary argument options to reflect the final acceptable CLI arguments.