### PR TITLE
Implement formatting

### DIFF
--- a/src/emitters/emitter.ts
+++ b/src/emitters/emitter.ts
@@ -23,4 +23,24 @@ export abstract class Emitter {
    * @param {Project} project - ts-morph project to be emitted.
    */
   abstract emit(project: Project): void;
+
+  /**
+   * Formats source files given a set of their file paths.
+   * @param sourceFilePaths - Set of file paths of source files to format.
+   * @param project - ts-morph project containing source files.
+   */
+  format(sourceFilePaths: Set<string>, project: Project): void {
+    sourceFilePaths.forEach(sourceFilePath =>
+      project.getSourceFile(sourceFilePath)?.formatText({
+        indentSize: 2,
+        ensureNewLineAtEndOfFile: true,
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false,
+        insertSpaceAfterOpeningAndBeforeClosingEmptyBraces: false,
+        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
+        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
+      })
+    );
+  }
 }

--- a/src/manipulators/manipulator.ts
+++ b/src/manipulators/manipulator.ts
@@ -14,7 +14,15 @@
     limitations under the License.
 */
 
-import {Diagnostic, ts, Node, Type, Statement, TypeFormatFlags} from 'ts-morph';
+import {
+  Diagnostic,
+  ts,
+  Node,
+  Type,
+  Statement,
+  TypeFormatFlags,
+  SourceFile,
+} from 'ts-morph';
 import {ErrorDetector} from '@/src/error_detectors/error_detector';
 import {Logger} from '@/src/loggers/logger';
 
@@ -42,8 +50,9 @@ export abstract class Manipulator {
   /**
    * Manipulates AST of project to fix for a specific flag given diagnostics.
    * @param {Diagnostic<ts.Diagnostic>[]} diagnostics - List of diagnostics outputted by parser.
+   * @return {Set<SourceFile>} Set of modified source files.
    */
-  abstract fixErrors(diagnostics: Diagnostic<ts.Diagnostic>[]): void;
+  abstract fixErrors(diagnostics: Diagnostic<ts.Diagnostic>[]): Set<SourceFile>;
 
   /**
    * Manipulates AST of project to fix for a specific flag given diagnostics.

--- a/src/manipulators/strict_null_checks_manipulator.ts
+++ b/src/manipulators/strict_null_checks_manipulator.ts
@@ -70,8 +70,9 @@ export class StrictNullChecksManipulator extends Manipulator {
   /**
    * Manipulates AST of project to fix for the strictNullChecks compiler flag given diagnostics.
    * @param {Diagnostic<ts.Diagnostic>[]} diagnostics - List of diagnostics outputted by parser
+   * @returns {Set<SourceFile>} Set of modified source files.
    */
-  fixErrors(diagnostics: Diagnostic<ts.Diagnostic>[]): void {
+  fixErrors(diagnostics: Diagnostic<ts.Diagnostic>[]): Set<SourceFile> {
     // Retrieve AST nodes corresponding to diagnostics with relevant error codes
     const errorNodes = this.errorDetector.getNodesFromDiagnostics(
       this.errorDetector.filterDiagnosticsByCode(
@@ -79,6 +80,9 @@ export class StrictNullChecksManipulator extends Manipulator {
         this.errorCodesToFix
       )
     );
+
+    // Set of modified source files.
+    const modifiedSourceFiles = new Set<SourceFile>();
 
     // Initialize map of declarations to their types
     const modifiedDeclarationTypes: DeclarationType = new Map<
@@ -191,6 +195,8 @@ export class StrictNullChecksManipulator extends Manipulator {
         );
       }
     );
+
+    return modifiedSourceFiles;
   }
 
   /**


### PR DESCRIPTION
## Issue
Fixes #31 

## Description
Before, the tool correctly modifies the source file ASTs, but when emitting back to the project, sometimes it would mess up the formatting, with wrong indents. To fix this, the runner now calls `format()`, a function of the `Emitter`, that takes in a set of modified source files and reformats them.